### PR TITLE
Nvidia unstable 10.1+cca/latest

### DIFF
--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -1268,14 +1268,28 @@ static PFlashCFI01 *virt_flash_create1(VirtMachineState *vms,
     return PFLASH_CFI01(dev);
 }
 
+/* Create pflash devices early for blockdev property support.
+ * For confidential VMs, devices are created but not mapped. */
 static void virt_flash_create(VirtMachineState *vms)
 {
-    if (virt_machine_is_confidential(vms)) {
+    /* Always create for property registration.
+     * CCA check moved to virt_flash_map() instead. */
+    vms->flash[0] = virt_flash_create1(vms, "virt.flash0", "pflash0");
+    vms->flash[1] = virt_flash_create1(vms, "virt.flash1", "pflash1");
+}
+
+static void virt_flash_realize(PFlashCFI01 *flash, hwaddr size)
+{
+    DeviceState *dev = DEVICE(flash);
+
+    if (dev->realized) {
         return;
     }
 
-    vms->flash[0] = virt_flash_create1(vms, "virt.flash0", "pflash0");
-    vms->flash[1] = virt_flash_create1(vms, "virt.flash1", "pflash1");
+    assert(QEMU_IS_ALIGNED(size, VIRT_FLASH_SECTOR_SIZE));
+    assert(size / VIRT_FLASH_SECTOR_SIZE <= UINT32_MAX);
+    qdev_prop_set_uint32(dev, "num-blocks", size / VIRT_FLASH_SECTOR_SIZE);
+    sysbus_realize_and_unref(SYS_BUS_DEVICE(dev), &error_fatal);
 }
 
 static void virt_flash_map1(PFlashCFI01 *flash,
@@ -1283,11 +1297,6 @@ static void virt_flash_map1(PFlashCFI01 *flash,
                             MemoryRegion *sysmem)
 {
     DeviceState *dev = DEVICE(flash);
-
-    assert(QEMU_IS_ALIGNED(size, VIRT_FLASH_SECTOR_SIZE));
-    assert(size / VIRT_FLASH_SECTOR_SIZE <= UINT32_MAX);
-    qdev_prop_set_uint32(dev, "num-blocks", size / VIRT_FLASH_SECTOR_SIZE);
-    sysbus_realize_and_unref(SYS_BUS_DEVICE(dev), &error_fatal);
 
     memory_region_add_subregion(sysmem, base,
                                 sysbus_mmio_get_region(SYS_BUS_DEVICE(dev),
@@ -1308,6 +1317,9 @@ static void virt_flash_map(VirtMachineState *vms,
      */
     hwaddr flashsize = vms->memmap[VIRT_FLASH].size / 2;
     hwaddr flashbase = vms->memmap[VIRT_FLASH].base;
+
+    virt_flash_realize(vms->flash[0], flashsize);
+    virt_flash_realize(vms->flash[1], flashsize);
 
     if (virt_machine_is_confidential(vms)) {
         return;
@@ -1373,6 +1385,10 @@ static bool virt_confidential_firmware_init(VirtMachineState *vms,
     MemoryRegion *fw_ram;
     hwaddr fw_base = vms->memmap[VIRT_FLASH].base;
     hwaddr fw_size = vms->memmap[VIRT_FLASH].size;
+    hwaddr flashsize = fw_size / 2;
+
+    virt_flash_realize(vms->flash[0], flashsize);
+    virt_flash_realize(vms->flash[1], flashsize);
 
     if (!MACHINE(vms)->firmware) {
         return false;
@@ -2319,8 +2335,6 @@ static void machvirt_init(MachineState *machine)
     bool has_ged = !vmc->no_ged;
     unsigned int smp_cpus = machine->smp.cpus;
     unsigned int max_cpus = machine->smp.max_cpus;
-
-    virt_flash_create(vms);
 
     possible_cpus = mc->possible_cpu_arch_ids(machine);
 
@@ -3652,6 +3666,15 @@ static void virt_instance_init(Object *obj)
     vms->oem_id = g_strndup(ACPI_BUILD_APPNAME6, 6);
     vms->oem_table_id = g_strndup(ACPI_BUILD_APPNAME8, 8);
     cxl_machine_init(obj, &vms->cxl_devices_state);
+
+    /*
+     * Create pflash devices early for blockdev property support.
+     * For confidential VMs, the devices are created but won't be
+     * mapped into memory (virt_flash_map checks machine->cgs).
+     * This allows libvirt 10.x to use:
+     *   -machine virt-10.1,pflash0=node,pflash1=node
+     */
+    virt_flash_create(vms);
 }
 
 static const TypeInfo virt_machine_info = {

--- a/linux-headers/asm-arm64/kvm.h
+++ b/linux-headers/asm-arm64/kvm.h
@@ -428,7 +428,6 @@ enum {
 /* List of configuration items accepted for KVM_CAP_ARM_RME_CONFIG_REALM */
 #define ARM_RME_CONFIG_RPV			0
 #define ARM_RME_CONFIG_HASH_ALGO		1
-#define ARM_RME_CONFIG_MEC			2
 
 #define ARM_RME_CONFIG_HASH_ALGO_SHA256		0
 #define ARM_RME_CONFIG_HASH_ALGO_SHA512		1
@@ -448,10 +447,6 @@ struct arm_rme_config {
 			__u32	hash_algo;
 		};
 
-		/* cfg == ARM_RME_CONFIG_MEC */
-		struct {
-			__u32	shared_mec;
-		};
 		/* Fix the size of the union */
 		__u8	reserved[256];
 	};

--- a/qapi/qom.json
+++ b/qapi/qom.json
@@ -1216,15 +1216,12 @@
 #     memory (unmeasured) and can then be read by a verifier to
 #     reconstruct the RIM.
 #
-# @shared-mec: Enable/disable usage of a shared MEC.
-#
 # Since: 10.0
 ##
 { 'struct': 'RmeGuestProperties',
   'data': { '*personalization-value': 'str',
             '*measurement-algorithm': 'RmeGuestMeasurementAlgorithm',
-            '*measurement-log': 'bool',
-            '*shared-mec': 'bool'} }
+            '*measurement-log': 'bool'} }
 
 ##
 # @ObjectType:

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -80,7 +80,6 @@ struct RmeGuest {
     uint8_t personalization_value[ARM_RME_CONFIG_RPV_SIZE];
     RmeGuestMeasurementAlgorithm measurement_algo;
     bool use_measurement_log;
-    bool use_shared_mec;
 
     RmeRamRegion init_ram;
     uint8_t ipa_bits;
@@ -435,9 +434,6 @@ static int rme_configure_one(RmeGuest *guest, uint32_t cfg, Error **errp)
         }
         cfg_str = "hash algorithm";
         break;
-    case ARM_RME_CONFIG_MEC:
-        args.shared_mec = guest->use_shared_mec;
-        break;
     default:
         g_assert_not_reached();
     }
@@ -457,7 +453,6 @@ static int rme_configure(Error **errp)
     const uint32_t config_options[] = {
         ARM_RME_CONFIG_RPV,
         ARM_RME_CONFIG_HASH_ALGO,
-        ARM_RME_CONFIG_MEC,
     };
 
     for (option = 0; option < ARRAY_SIZE(config_options); option++) {
@@ -685,20 +680,6 @@ static void rme_set_measurement_log(Object *obj, bool value, Error **errp)
     guest->use_measurement_log = value;
 }
 
-static bool rme_get_shared_mec(Object *obj, Error **errp)
-{
-    RmeGuest *guest = RME_GUEST(obj);
-
-    return guest->use_shared_mec;
-}
-
-static void rme_set_shared_mec(Object *obj, bool value, Error **errp)
-{
-    RmeGuest *guest = RME_GUEST(obj);
-
-    guest->use_shared_mec = value;
-}
-
 static void rme_guest_class_init(ObjectClass *oc, const void *data)
 {
     object_class_property_add_str(oc, "personalization-value", rme_get_rpv,
@@ -719,12 +700,6 @@ static void rme_guest_class_init(ObjectClass *oc, const void *data)
                                    rme_set_measurement_log);
     object_class_property_set_description(oc, "measurement-log",
             "Enable/disable Realm measurement log");
-
-    object_class_property_add_bool(oc, "shared-mec",
-                                   rme_get_shared_mec,
-                                   rme_set_shared_mec);
-    object_class_property_set_description(oc, "shared-mec",
-            "Enable/disable usage of a shared Memory Encryption Context (MEC)");
 }
 
 static void rme_guest_init(Object *obj)


### PR DESCRIPTION
Summary
Created virt_flash_realize() so pflash devices are realized even when the confidential firmware path is taken, and moved flash creation back into virt_instance_init(). This restores libvirt’s pflash0= support while preventing the qdev_assert_realized_properly crash for CCA Realm guests (010737d5e05e1c15b5c0daf5773fc03c4d7db6e7).
Reverted the MEC property patch for now, because current kernels reject the new ARM_RME_CONFIG_MEC option—causing Realm creation to fail by default (9e4c32a645cdf859f6e7963b34f7a0278de8d3c7).

Impact
Libvirt 10.x can again wire the pflash devices on Arm virt machines.
Confidential/Realm guests no longer panic due to an unrealized pflash device.
User space stays compatible with kernels that haven’t gained MEC support yet; Realms boot out-of-the-box, and the MEC config can be reintroduced when the kernel side is ready.