### PR TITLE
NVIDIA: SAUCE: hw/arm/virt: Define MEC as shared or private

### DIFF
--- a/linux-headers/asm-arm64/kvm.h
+++ b/linux-headers/asm-arm64/kvm.h
@@ -428,6 +428,8 @@ enum {
 /* List of configuration items accepted for KVM_CAP_ARM_RME_CONFIG_REALM */
 #define ARM_RME_CONFIG_RPV			0
 #define ARM_RME_CONFIG_HASH_ALGO		1
+#define ARM_RME_CONFIG_MEC			2
+#define ARM_RME_CONFIG_MEC_QUERY		3
 
 #define ARM_RME_CONFIG_HASH_ALGO_SHA256		0
 #define ARM_RME_CONFIG_HASH_ALGO_SHA512		1
@@ -447,6 +449,16 @@ struct arm_rme_config {
 			__u32	hash_algo;
 		};
 
+		/* cfg == ARM_RME_CONFIG_MEC */
+		struct {
+			__u32	shared_mec;
+		};
+
+		/* cfg == ARM_RME_CONFIG_MEC_QUERY - output */
+		struct {
+			__u32	mec_supported;	/* 0=not supported, 1=supported */
+			__u32	mec_count;	/* Number of available MECIDs */
+		};
 		/* Fix the size of the union */
 		__u8	reserved[256];
 	};

--- a/qapi/qom.json
+++ b/qapi/qom.json
@@ -1216,12 +1216,15 @@
 #     memory (unmeasured) and can then be read by a verifier to
 #     reconstruct the RIM.
 #
+# @shared-mec: Enable/disable usage of a shared MEC.
+#
 # Since: 10.0
 ##
 { 'struct': 'RmeGuestProperties',
   'data': { '*personalization-value': 'str',
             '*measurement-algorithm': 'RmeGuestMeasurementAlgorithm',
-            '*measurement-log': 'bool'} }
+            '*measurement-log': 'bool',
+            '*shared-mec': 'bool'} }
 
 ##
 # @ObjectType:

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -80,6 +80,8 @@ struct RmeGuest {
     uint8_t personalization_value[ARM_RME_CONFIG_RPV_SIZE];
     RmeGuestMeasurementAlgorithm measurement_algo;
     bool use_measurement_log;
+    bool mec_specified;
+    bool use_shared_mec;
 
     RmeRamRegion init_ram;
     uint8_t ipa_bits;
@@ -408,6 +410,59 @@ static int rme_close_measurement_log(Error **errp)
     return 0;
 }
 
+static int rme_configure_mec(RmeGuest *guest, Error **errp)
+{
+    struct arm_rme_config mec_query = {
+        .cfg = ARM_RME_CONFIG_MEC_QUERY,
+    };
+    struct arm_rme_config mec_cfg = {
+        .cfg = ARM_RME_CONFIG_MEC,
+        .shared_mec = guest->use_shared_mec,
+    };
+    bool private_mec_requested = (guest->use_shared_mec == 0);
+    int ret = 0;
+
+    /* Skip MEC configuration if not requested by user */
+    if (!guest->mec_specified) {
+        return 0;
+    }
+
+    /* First query if MEC is supported by the kernel */
+    ret = kvm_vm_enable_cap(kvm_state, KVM_CAP_ARM_RME, 0,
+                            KVM_CAP_ARM_RME_CONFIG_REALM, (intptr_t)&mec_query);
+    if (ret) {
+        if (private_mec_requested) {
+            error_setg_errno(errp, -ret,
+                "Private MECID requested but MEC query failed - kernel may not support MEC");
+            return ret;
+        }
+        /* For shared MEC, we can continue without MEC support */
+        warn_report("MEC query failed - continuing without MEC configuration");
+        return 0;
+    }
+
+    /* Check if MEC is supported */
+    if (!mec_query.mec_supported) {
+        if (private_mec_requested) {
+            error_setg_errno(errp, ENOTSUP,
+                "Private MECID requested but MEC is not supported by the kernel");
+            return -ENOTSUP;
+        }
+        /* For shared MEC, we can continue without MEC support */
+        warn_report("MEC is not supported by the kernel - continuing without MEC configuration");
+        return 0;
+    }
+
+    ret = kvm_vm_enable_cap(kvm_state, KVM_CAP_ARM_RME, 0,
+                            KVM_CAP_ARM_RME_CONFIG_REALM, (intptr_t)&mec_cfg);
+    if (ret) {
+        error_setg_errno(errp, -ret, "MEC configuration failed");
+        return ret;
+    }
+
+    return 0;
+}
+
 static int rme_configure_one(RmeGuest *guest, uint32_t cfg, Error **errp)
 {
     int ret;
@@ -461,6 +516,12 @@ static int rme_configure(Error **errp)
             return ret;
         }
     }
+
+    ret = rme_configure_mec(rme_guest, errp);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -680,6 +741,21 @@ static void rme_set_measurement_log(Object *obj, bool value, Error **errp)
     guest->use_measurement_log = value;
 }
 
+static bool rme_get_shared_mec(Object *obj, Error **errp)
+{
+    RmeGuest *guest = RME_GUEST(obj);
+
+    return guest->use_shared_mec;
+}
+
+static void rme_set_shared_mec(Object *obj, bool value, Error **errp)
+{
+    RmeGuest *guest = RME_GUEST(obj);
+
+    guest->mec_specified = true;
+    guest->use_shared_mec = value;
+}
+
 static void rme_guest_class_init(ObjectClass *oc, const void *data)
 {
     object_class_property_add_str(oc, "personalization-value", rme_get_rpv,
@@ -700,6 +776,12 @@ static void rme_guest_class_init(ObjectClass *oc, const void *data)
                                    rme_set_measurement_log);
     object_class_property_set_description(oc, "measurement-log",
             "Enable/disable Realm measurement log");
+
+    object_class_property_add_bool(oc, "shared-mec",
+                                   rme_get_shared_mec,
+                                   rme_set_shared_mec);
+    object_class_property_set_description(oc, "shared-mec",
+            "Enable/disable usage of a shared Memory Encryption Context (MEC)");
 }
 
 static void rme_guest_init(Object *obj)
@@ -710,6 +792,7 @@ static void rme_guest_init(Object *obj)
     }
     rme_guest = RME_GUEST(obj);
     rme_guest->measurement_algo = RME_GUEST_MEASUREMENT_ALGORITHM_SHA512;
+    rme_guest->mec_specified = false;
 }
 
 static void rme_guest_finalize(Object *obj)


### PR DESCRIPTION
Kernel MEC support has landed, reintroduce this updated patch which enables shared MEC functionality in QEMU.  This patch also contains functionality for handling kernels that don't have MEC support.  Below is a short summary of MEC behavior:

Set MEC in QEMU:
 - If no shareability is requested, use the kernel default.
 - If private MEC is requested, abort initialization if setting MEC fails.
 - If shared MEC is requested, try setting MEC. If there is no kernel support, continue.