### PR TITLE
NVIDIA: SAUCE: Reset gpu_id each time building DSDT

### DIFF
--- a/hw/acpi/acpi_egm_memory.c
+++ b/hw/acpi/acpi_egm_memory.c
@@ -115,6 +115,11 @@ typedef struct DsdtInfo {
     int bus;
 } DsdtInfo;
 
+void acpi_egm_memory_reset_gpu_id(void)
+{
+    gpu_id = 0;
+}
+
 static int build_all_acpi_egm_memory_dsdt(Object *obj, void *opaque)
 {
     MachineState *ms = MACHINE(qdev_get_machine());

--- a/hw/pci-host/gpex-acpi.c
+++ b/hw/pci-host/gpex-acpi.c
@@ -110,6 +110,9 @@ void acpi_dsdt_add_gpex(Aml *scope, struct GPEXConfig *cfg)
     CrsRangeEntry *entry;
     int i;
 
+    /* Reset GPU ID for each complete ACPI table build */
+    acpi_egm_memory_reset_gpu_id();
+
     /* start to construct the tables for pxb */
     crs_range_set_init(&crs_range_set);
     if (bus) {

--- a/include/hw/acpi/acpi_egm_memory.h
+++ b/include/hw/acpi/acpi_egm_memory.h
@@ -20,5 +20,6 @@ typedef struct AcpiEgmMemory {
 } AcpiEgmMemory;
 
 void build_acpi_egm_memory_dsdt(Aml *dev, int bus);
+void acpi_egm_memory_reset_gpu_id(void);
 
 #endif


### PR DESCRIPTION
There is an assert in build_append_nameseg() that enforces the length of ACPI segments to 4 characters:

qemu-system-aarch64: hw/acpi/aml-build.c:202: build_append_nameseg: Assertion len <= ACPI_NAMESEG_LEN failed.

This assert can be hit when building the EGM DSDT entries because the gpu_id can overflow a single character.

To avoid hitting this assert, always reset the gpu_id before building the DSDT table.