### PR TITLE
Qemu bugfixes for numa distance and huge pfnmap alignment for 10.2

### DIFF
--- a/hw/acpi/pci.c
+++ b/hw/acpi/pci.c
@@ -88,18 +88,35 @@ OBJECT_DEFINE_TYPE_WITH_INTERFACES(AcpiGenericInitiator, acpi_generic_initiator,
 
 OBJECT_DECLARE_SIMPLE_TYPE(AcpiGenericInitiator, ACPI_GENERIC_INITIATOR)
 
+static GPtrArray *acpi_generic_initiator_list;
+
 static void acpi_generic_initiator_init(Object *obj)
 {
     AcpiGenericInitiator *gi = ACPI_GENERIC_INITIATOR(obj);
 
     gi->node = MAX_NODES;
     gi->pci_dev = NULL;
+
+    /* Initialize array on first use */
+    if (!acpi_generic_initiator_list) {
+        acpi_generic_initiator_list = g_ptr_array_new();
+    }
+
+    g_ptr_array_add(acpi_generic_initiator_list, gi);
 }
 
 static void acpi_generic_initiator_finalize(Object *obj)
 {
     AcpiGenericInitiator *gi = ACPI_GENERIC_INITIATOR(obj);
 
+    if (acpi_generic_initiator_list) {
+        g_ptr_array_remove(acpi_generic_initiator_list, gi);
+
+        if (acpi_generic_initiator_list->len == 0) {
+            g_ptr_array_free(acpi_generic_initiator_list, true);
+            acpi_generic_initiator_list = NULL;
+        }
+    }
     g_free(gi->pci_dev);
 }
 
@@ -145,20 +162,15 @@ static void acpi_generic_initiator_class_init(ObjectClass *oc, const void *data)
         "NUMA node associated with the PCI device");
 }
 
-static int build_acpi_generic_initiator(Object *obj, void *opaque)
+
+static void build_acpi_generic_initiator(AcpiGenericInitiator *gi,
+                                         GArray *table_data)
 {
     MachineState *ms = MACHINE(qdev_get_machine());
-    AcpiGenericInitiator *gi;
-    GArray *table_data = opaque;
     int32_t devfn;
     uint8_t bus;
     Object *o;
 
-    if (!object_dynamic_cast(obj, TYPE_ACPI_GENERIC_INITIATOR)) {
-        return 0;
-    }
-
-    gi = ACPI_GENERIC_INITIATOR(obj);
     if (gi->node >= ms->numa_state->num_nodes) {
         error_printf("%s: Specified node %d is invalid.\n",
                      TYPE_ACPI_GENERIC_INITIATOR, gi->node);
@@ -178,8 +190,22 @@ static int build_acpi_generic_initiator(Object *obj, void *opaque)
     assert(devfn >= 0 && devfn < PCI_DEVFN_MAX);
 
     build_srat_pci_generic_initiator(table_data, gi->node, 0, bus, devfn);
+}
 
-    return 0;
+static void build_all_acpi_generic_initiators(GArray *table_data)
+{
+    AcpiGenericInitiator *gi;
+    guint i;
+
+    if (!acpi_generic_initiator_list) {
+        return;
+    }
+
+    /* Iterate array in insertion order */
+    for (i = 0; i < acpi_generic_initiator_list->len; i++) {
+        gi = g_ptr_array_index(acpi_generic_initiator_list, i);
+        build_acpi_generic_initiator(gi, table_data);
+    }
 }
 
 typedef struct AcpiGenericPort {
@@ -295,9 +321,8 @@ static int build_acpi_generic_port(Object *obj, void *opaque)
 
 void build_srat_generic_affinity_structures(GArray *table_data)
 {
-    object_child_foreach_recursive(object_get_root(),
-                                   build_acpi_generic_initiator,
-                                   table_data);
+    build_all_acpi_generic_initiators(table_data);
+
     object_child_foreach_recursive(object_get_root(), build_acpi_generic_port,
                                    table_data);
 }

--- a/hw/vfio/display.c
+++ b/hw/vfio/display.c
@@ -446,13 +446,13 @@ static void vfio_display_region_update(void *opaque)
 
     if (!dpy->region.buffer.size) {
         /* mmap region */
+        Error *error = NULL;
         ret = vfio_region_setup(OBJECT(vdev), &vdev->vbasedev,
                                 &dpy->region.buffer,
                                 plane.region_index,
-                                "display");
+                                "display", &error);
         if (ret != 0) {
-            error_report("%s: vfio_region_setup(%d): %s",
-                         __func__, plane.region_index, strerror(-ret));
+            error_report_err(error);
             goto err;
         }
         ret = vfio_region_mmap(&dpy->region.buffer);

--- a/hw/vfio/pci.c
+++ b/hw/vfio/pci.c
@@ -2990,11 +2990,10 @@ bool vfio_pci_populate_device(VFIOPCIDevice *vdev, Error **errp)
         char *name = g_strdup_printf("%s BAR %d", vbasedev->name, i);
 
         ret = vfio_region_setup(OBJECT(vdev), vbasedev,
-                                &vdev->bars[i].region, i, name);
+                                &vdev->bars[i].region, i, name, errp);
         g_free(name);
 
         if (ret) {
-            error_setg_errno(errp, -ret, "failed to get region %d info", i);
             return false;
         }
 

--- a/hw/vfio/region.c
+++ b/hw/vfio/region.c
@@ -286,7 +286,10 @@ static void vfio_subregion_unmap(VFIORegion *region, int index)
 
 int vfio_region_mmap(VFIORegion *region)
 {
+    void *map_base, *map_align;
     int i, ret, prot = 0;
+    off_t map_offset = 0;
+    size_t align;
     char *name;
     int fd;
 
@@ -297,41 +300,61 @@ int vfio_region_mmap(VFIORegion *region)
     prot |= region->flags & VFIO_REGION_INFO_FLAG_READ ? PROT_READ : 0;
     prot |= region->flags & VFIO_REGION_INFO_FLAG_WRITE ? PROT_WRITE : 0;
 
+    /*
+     * Align the mmap for more efficient mapping in the kernel. Ideally
+     * we'd know the PMD and PUD mapping sizes to use as discrete alignment
+     * intervals, but we don't. As of Linux v6.19, the largest PUD size
+     * supporting huge pfnmap is 1GiB (ARCH_SUPPORTS_PUD_PFNMAP is only set
+     * on x86_64).
+     *
+     * Align by power-of-two of the size of the entire region - capped
+     * by 1G - and place the sparse subregions at their appropriate offset.
+     * This will get maximum alignment.
+     *
+     * NB. qemu_memalign() and friends actually allocate memory, whereas
+     * the region size here can exceed host memory, therefore we manually
+     * create an oversized anonymous mapping and clean it up for alignment.
+     */
+
+    align = MIN(pow2ceil(region->size), 1 * GiB);
+
+    map_base = mmap(0, region->size + align, PROT_NONE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (map_base == MAP_FAILED) {
+        ret = -errno;
+        trace_vfio_region_mmap_fault(memory_region_name(region->mem), -1,
+                                     region->fd_offset,
+                                     region->fd_offset + region->size - 1, ret);
+        return ret;
+    }
+
+    fd = vfio_device_get_region_fd(region->vbasedev, region->nr);
+
+    map_align = (void *)ROUND_UP((uintptr_t)map_base, (uintptr_t)align);
+    munmap(map_base, map_align - map_base);
+    munmap(map_align + region->size,
+           align - (map_align - map_base));
+
+    /*
+     * Regions should already be sorted by vfio_setup_region_sparse_mmaps().
+     * This is critical for the following algorithm which relies on range
+     * offsets being in ascending order.
+     */
     for (i = 0; i < region->nr_mmaps; i++) {
-        size_t align = MIN(1ULL << ctz64(region->mmaps[i].size), 1 * GiB);
-        void *map_base, *map_align;
-
-        /*
-         * Align the mmap for more efficient mapping in the kernel.  Ideally
-         * we'd know the PMD and PUD mapping sizes to use as discrete alignment
-         * intervals, but we don't.  As of Linux v6.12, the largest PUD size
-         * supporting huge pfnmap is 1GiB (ARCH_SUPPORTS_PUD_PFNMAP is only set
-         * on x86_64).  Align by power-of-two size, capped at 1GiB.
-         *
-         * NB. qemu_memalign() and friends actually allocate memory, whereas
-         * the region size here can exceed host memory, therefore we manually
-         * create an oversized anonymous mapping and clean it up for alignment.
-         */
-        map_base = mmap(0, region->mmaps[i].size + align, PROT_NONE,
-                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (map_base == MAP_FAILED) {
-            ret = -errno;
-            goto no_mmap;
-        }
-
-        fd = vfio_device_get_region_fd(region->vbasedev, region->nr);
-
-        map_align = (void *)ROUND_UP((uintptr_t)map_base, (uintptr_t)align);
-        munmap(map_base, map_align - map_base);
-        munmap(map_align + region->mmaps[i].size,
-               align - (map_align - map_base));
-
-        region->mmaps[i].mmap = mmap(map_align, region->mmaps[i].size, prot,
+        munmap(map_align + map_offset, region->mmaps[i].offset - map_offset);
+        region->mmaps[i].mmap = mmap(map_align + region->mmaps[i].offset,
+                                     region->mmaps[i].size, prot,
                                      MAP_SHARED | MAP_FIXED, fd,
                                      region->fd_offset +
                                      region->mmaps[i].offset);
         if (region->mmaps[i].mmap == MAP_FAILED) {
             ret = -errno;
+            /*
+             * Only unmap the rest of the region. Any mmaps that were successful
+             * will be unmapped in no_mmap.
+             */
+            munmap(map_align + region->mmaps[i].offset,
+                   region->size - region->mmaps[i].offset);
             goto no_mmap;
         }
 
@@ -349,6 +372,15 @@ int vfio_region_mmap(VFIORegion *region)
                                region->mmaps[i].offset,
                                region->mmaps[i].offset +
                                region->mmaps[i].size - 1);
+
+        map_offset = region->mmaps[i].offset + region->mmaps[i].size;
+    }
+
+    /*
+     * Unmap the rest of the region not covered by sparse mmap.
+     */
+    if (map_offset < region->size) {
+        munmap(map_align + map_offset, region->size - map_offset);
     }
 
     return 0;

--- a/hw/vfio/region.c
+++ b/hw/vfio/region.c
@@ -162,7 +162,8 @@ static int vfio_mmap_compare_offset(const void *a, const void *b)
 }
 
 static int vfio_setup_region_sparse_mmaps(VFIORegion *region,
-                                          struct vfio_region_info *info)
+                                          struct vfio_region_info *info,
+                                          Error **errp)
 {
     struct vfio_info_cap_header *hdr;
     struct vfio_region_info_cap_sparse_mmap *sparse;
@@ -209,12 +210,12 @@ static int vfio_setup_region_sparse_mmaps(VFIORegion *region,
             off_t prev_end = region->mmaps[i - 1].offset +
                              region->mmaps[i - 1].size;
             if (prev_end > region->mmaps[i].offset) {
-                error_report("%s: overlapping sparse mmap regions detected "
-                             "in region %d: [0x%"PRIx64"-0x%"PRIx64"] overlaps "
-                             "with [0x%"PRIx64"-0x%"PRIx64"]",
-                             __func__, region->nr, region->mmaps[i - 1].offset,
-                             prev_end - 1, region->mmaps[i].offset,
-                             region->mmaps[i].offset + region->mmaps[i].size - 1);
+                error_setg(errp, "%s: overlapping sparse mmap regions detected "
+                           "in region %d: [0x%"PRIx64"-0x%"PRIx64"] overlaps "
+                           "with [0x%"PRIx64"-0x%"PRIx64"]",
+                           __func__, region->nr, region->mmaps[i - 1].offset,
+                           prev_end - 1, region->mmaps[i].offset,
+                           region->mmaps[i].offset + region->mmaps[i].size - 1);
                 g_free(region->mmaps);
                 region->mmaps = NULL;
                 region->nr_mmaps = 0;
@@ -227,13 +228,14 @@ static int vfio_setup_region_sparse_mmaps(VFIORegion *region,
 }
 
 int vfio_region_setup(Object *obj, VFIODevice *vbasedev, VFIORegion *region,
-                      int index, const char *name)
+                      int index, const char *name, Error **errp)
 {
     struct vfio_region_info *info = NULL;
     int ret;
 
     ret = vfio_device_get_region_info(vbasedev, index, &info);
     if (ret) {
+        error_setg_errno(errp, -ret, "failed to get region %d info", index);
         return ret;
     }
 
@@ -252,7 +254,7 @@ int vfio_region_setup(Object *obj, VFIODevice *vbasedev, VFIORegion *region,
         if (!vbasedev->no_mmap &&
             region->flags & VFIO_REGION_INFO_FLAG_MMAP) {
 
-            ret = vfio_setup_region_sparse_mmaps(region, info);
+            ret = vfio_setup_region_sparse_mmaps(region, info, errp);
 
             if (ret == -ENODEV) {
                 region->nr_mmaps = 1;

--- a/hw/vfio/region.c
+++ b/hw/vfio/region.c
@@ -148,6 +148,19 @@ static const MemoryRegionOps vfio_region_ops = {
     },
 };
 
+static int vfio_mmap_compare_offset(const void *a, const void *b)
+{
+    const VFIOMmap *mmap_a = a;
+    const VFIOMmap *mmap_b = b;
+
+    if (mmap_a->offset < mmap_b->offset) {
+        return -1;
+    } else if (mmap_a->offset > mmap_b->offset) {
+        return 1;
+    }
+    return 0;
+}
+
 static int vfio_setup_region_sparse_mmaps(VFIORegion *region,
                                           struct vfio_region_info *info)
 {
@@ -181,6 +194,35 @@ static int vfio_setup_region_sparse_mmaps(VFIORegion *region,
     region->nr_mmaps = j;
     region->mmaps = g_realloc(region->mmaps, j * sizeof(VFIOMmap));
 
+    /*
+     * Sort sparse mmaps by offset to ensure proper handling of gaps
+     * and predictable mapping order in vfio_region_mmap().
+     */
+    if (region->nr_mmaps > 1) {
+        qsort(region->mmaps, region->nr_mmaps, sizeof(VFIOMmap),
+              vfio_mmap_compare_offset);
+
+        /*
+         * Validate that sparse regions don't overlap after sorting.
+         */
+        for (i = 1; i < region->nr_mmaps; i++) {
+            off_t prev_end = region->mmaps[i - 1].offset +
+                             region->mmaps[i - 1].size;
+            if (prev_end > region->mmaps[i].offset) {
+                error_report("%s: overlapping sparse mmap regions detected "
+                             "in region %d: [0x%"PRIx64"-0x%"PRIx64"] overlaps "
+                             "with [0x%"PRIx64"-0x%"PRIx64"]",
+                             __func__, region->nr, region->mmaps[i - 1].offset,
+                             prev_end - 1, region->mmaps[i].offset,
+                             region->mmaps[i].offset + region->mmaps[i].size - 1);
+                g_free(region->mmaps);
+                region->mmaps = NULL;
+                region->nr_mmaps = 0;
+                return -EINVAL;
+            }
+        }
+    }
+
     return 0;
 }
 
@@ -212,11 +254,13 @@ int vfio_region_setup(Object *obj, VFIODevice *vbasedev, VFIORegion *region,
 
             ret = vfio_setup_region_sparse_mmaps(region, info);
 
-            if (ret) {
+            if (ret == -ENODEV) {
                 region->nr_mmaps = 1;
                 region->mmaps = g_new0(VFIOMmap, region->nr_mmaps);
                 region->mmaps[0].offset = 0;
                 region->mmaps[0].size = region->size;
+            } else if (ret) {
+                return ret;
             }
         }
     }

--- a/hw/vfio/vfio-region.h
+++ b/hw/vfio/vfio-region.h
@@ -38,7 +38,7 @@ void vfio_region_write(void *opaque, hwaddr addr,
 uint64_t vfio_region_read(void *opaque,
                           hwaddr addr, unsigned size);
 int vfio_region_setup(Object *obj, VFIODevice *vbasedev, VFIORegion *region,
-                      int index, const char *name);
+                      int index, const char *name, Error **errp);
 int vfio_region_mmap(VFIORegion *region);
 void vfio_region_mmaps_set_enabled(VFIORegion *region, bool enabled);
 void vfio_region_unmap(VFIORegion *region);


### PR DESCRIPTION
This PR addresses the following bugs:

1. Correct setting of numa distances
    - This is under internal review
2. [[PATCH v4 0/3] hw/vfio: Enable hugepfnmap for non-power-of-2 device memory regions](https://lore.kernel.org/all/20260217153010.408739-1-ankita@nvidia.com)
    - Backported from the latest posting that is pulled into qemu.