### PR TITLE
 Backport MSI doorbell GPA direct retrieval for accelerated SMMUv3

### DIFF
--- a/hw/arm/smmuv3-accel.c
+++ b/hw/arm/smmuv3-accel.c
@@ -692,6 +692,15 @@ static AddressSpace *smmuv3_accel_find_msi_as(PCIBus *bus, void *opaque,
     }
 }
 
+static uint64_t smmuv3_accel_get_msi_gpa(PCIBus *bus, void *opaque, int devfn)
+{
+    SMMUState *bs = opaque;
+    SMMUv3State *s = ARM_SMMUV3(bs);
+
+    g_assert(s->msi_gpa);
+    return s->msi_gpa;
+}
+
 static bool smmuv3_accel_pdev_allowed(PCIDevice *pdev, bool *vfio_pci)
 {
 
@@ -788,6 +797,7 @@ static const PCIIOMMUOps smmuv3_accel_ops = {
     .set_iommu_device = smmuv3_accel_set_iommu_device,
     .unset_iommu_device = smmuv3_accel_unset_iommu_device,
     .get_msi_address_space = smmuv3_accel_find_msi_as,
+    .get_msi_direct_gpa = smmuv3_accel_get_msi_gpa,
 };
 
 void smmuv3_accel_idr_override(SMMUv3State *s)

--- a/hw/arm/smmuv3-accel.c
+++ b/hw/arm/smmuv3-accel.c
@@ -672,26 +672,6 @@ static void smmuv3_accel_unset_iommu_device(PCIBus *bus, void *opaque,
     }
 }
 
-static AddressSpace *smmuv3_accel_find_msi_as(PCIBus *bus, void *opaque,
-                                              int devfn)
-{
-    SMMUState *bs = opaque;
-    SMMUPciBus *sbus = smmu_get_sbus(bs, bus);
-    SMMUv3AccelDevice *accel_dev = smmuv3_accel_get_dev(bs, sbus, bus, devfn);
-    SMMUDevice *sdev = &accel_dev->sdev;
-
-    /*
-     * If the assigned vfio-pci dev has S1 translation enabled by
-     * Guest, return IOMMU address space for MSI translation.
-     * Otherwise, return system address space.
-     */
-    if (accel_dev->s1_hwpt) {
-        return &sdev->as;
-    } else {
-        return &address_space_memory;
-    }
-}
-
 static uint64_t smmuv3_accel_get_msi_gpa(PCIBus *bus, void *opaque, int devfn)
 {
     SMMUState *bs = opaque;
@@ -796,7 +776,6 @@ static const PCIIOMMUOps smmuv3_accel_ops = {
     .get_viommu_flags = smmuv3_accel_get_viommu_flags,
     .set_iommu_device = smmuv3_accel_set_iommu_device,
     .unset_iommu_device = smmuv3_accel_unset_iommu_device,
-    .get_msi_address_space = smmuv3_accel_find_msi_as,
     .get_msi_direct_gpa = smmuv3_accel_get_msi_gpa,
 };
 

--- a/hw/arm/smmuv3.c
+++ b/hw/arm/smmuv3.c
@@ -2121,6 +2121,8 @@ static const Property smmuv3_properties[] = {
     DEFINE_PROP_UINT8("oas", SMMUv3State, oas, 44),
     DEFINE_PROP_BOOL("pasid", SMMUv3State, pasid, false),
     DEFINE_PROP_BOOL("cmdqv", SMMUv3State, cmdqv, false),
+    /* GPA of MSI doorbell, for SMMUv3 accel use. */
+    DEFINE_PROP_UINT64("msi-gpa", SMMUv3State, msi_gpa, 0),
 };
 
 static void smmuv3_instance_init(Object *obj)

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -3184,6 +3184,25 @@ static void virt_machine_device_pre_plug_cb(HotplugHandler *hotplug_dev,
             /* The new SMMUv3 device is specific to the PCI bus */
             object_property_set_bool(OBJECT(dev), "smmu_per_bus", true, NULL);
         }
+        if (object_property_get_bool(OBJECT(dev), "accel", &error_abort)) {
+            hwaddr db_start = 0;
+
+            if (!kvm_enabled() || !kvm_irqchip_in_kernel()) {
+                error_setg(errp, "SMMUv3 accel=on requires KVM with "
+                           "kernel-irqchip=on support");
+                return;
+            }
+
+            if (vms->msi_controller == VIRT_MSI_CTRL_ITS) {
+                /* GITS_TRANSLATER page + offset */
+                db_start = base_memmap[VIRT_GIC_ITS].base + 0x10000 + 0x40;
+            } else if (vms->msi_controller == VIRT_MSI_CTRL_GICV2M) {
+                /* MSI_SETSPI_NS page + offset */
+                db_start = base_memmap[VIRT_GIC_V2M].base + 0x40;
+            }
+            object_property_set_uint(OBJECT(dev), "msi-gpa", db_start,
+                                     &error_abort);
+        }
     }
 }
 

--- a/hw/pci/pci.c
+++ b/hw/pci/pci.c
@@ -2947,6 +2947,23 @@ bool pci_device_get_iommu_bus_devfn(PCIDevice *dev, PCIBus **piommu_bus,
     return aliased;
 }
 
+bool pci_device_iommu_msi_direct_gpa(PCIDevice *dev, hwaddr *out_doorbell)
+{
+    PCIBus *bus;
+    PCIBus *iommu_bus;
+    int devfn;
+
+    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
+    if (iommu_bus) {
+        if (iommu_bus->iommu_ops->get_msi_direct_gpa) {
+            *out_doorbell = iommu_bus->iommu_ops->get_msi_direct_gpa(bus,
+                                iommu_bus->iommu_opaque, devfn);
+            return true;
+        }
+    }
+    return false;
+}
+
 AddressSpace *pci_device_iommu_address_space(PCIDevice *dev)
 {
     PCIBus *bus;

--- a/hw/pci/pci.c
+++ b/hw/pci/pci.c
@@ -2978,25 +2978,6 @@ AddressSpace *pci_device_iommu_address_space(PCIDevice *dev)
     return &address_space_memory;
 }
 
-AddressSpace *pci_device_iommu_msi_address_space(PCIDevice *dev)
-{
-    PCIBus *bus;
-    PCIBus *iommu_bus;
-    int devfn;
-
-    pci_device_get_iommu_bus_devfn(dev, &iommu_bus, &bus, &devfn);
-    if (iommu_bus) {
-        if (iommu_bus->iommu_ops->get_msi_address_space) {
-            return iommu_bus->iommu_ops->get_msi_address_space(bus,
-                                 iommu_bus->iommu_opaque, devfn);
-        } else {
-            return iommu_bus->iommu_ops->get_address_space(bus,
-                                 iommu_bus->iommu_opaque, devfn);
-        }
-    }
-    return &address_space_memory;
-}
-
 int pci_iommu_init_iotlb_notifier(PCIDevice *dev, IOMMUNotifier *n,
                                   IOMMUNotify fn, void *opaque)
 {

--- a/include/hw/arm/smmuv3.h
+++ b/include/hw/arm/smmuv3.h
@@ -73,6 +73,7 @@ struct SMMUv3State {
     uint8_t oas;
     bool pasid;
     bool cmdqv;
+    uint64_t msi_gpa;
 };
 
 typedef enum {

--- a/include/hw/pci/pci.h
+++ b/include/hw/pci/pci.h
@@ -653,21 +653,6 @@ typedef struct PCIIOMMUOps {
                             hwaddr addr, bool lpig, uint16_t prgi, bool is_read,
                             bool is_write);
     /**
-     * @get_msi_address_space: get the address space for MSI doorbell address
-     * for devices
-     *
-     * Optional callback which returns a pointer to an #AddressSpace. This
-     * is required if MSI doorbell also gets translated through IOMMU(eg: ARM)
-     *
-     * @bus: the #PCIBus being accessed.
-     *
-     * @opaque: the data passed to pci_setup_iommu().
-     *
-     * @devfn: device and function number
-     */
-    AddressSpace * (*get_msi_address_space)(PCIBus *bus, void *opaque,
-                                            int devfn);
-    /**
      * @get_msi_direct_gpa: get the guest physical address of MSI doorbell
      * for the device on a PCI bus.
      *
@@ -691,7 +676,6 @@ AddressSpace *pci_device_iommu_address_space(PCIDevice *dev);
 bool pci_device_set_iommu_device(PCIDevice *dev, HostIOMMUDevice *hiod,
                                  Error **errp);
 void pci_device_unset_iommu_device(PCIDevice *dev);
-AddressSpace *pci_device_iommu_msi_address_space(PCIDevice *dev);
 bool pci_device_iommu_msi_direct_gpa(PCIDevice *dev, hwaddr *out_doorbell);
 
 /**

--- a/include/hw/pci/pci.h
+++ b/include/hw/pci/pci.h
@@ -667,6 +667,22 @@ typedef struct PCIIOMMUOps {
      */
     AddressSpace * (*get_msi_address_space)(PCIBus *bus, void *opaque,
                                             int devfn);
+    /**
+     * @get_msi_direct_gpa: get the guest physical address of MSI doorbell
+     * for the device on a PCI bus.
+     *
+     * Optional callback. If implemented, it must return a valid guest
+     * physical address for the MSI doorbell
+     *
+     * @bus: the #PCIBus being accessed.
+     *
+     * @opaque: the data passed to pci_setup_iommu().
+     *
+     * @devfn: device and function number
+     *
+     * Returns: the guest physical address of the MSI doorbell.
+     */
+    uint64_t (*get_msi_direct_gpa)(PCIBus *bus, void *opaque, int devfn);
 } PCIIOMMUOps;
 
 bool pci_device_get_iommu_bus_devfn(PCIDevice *dev, PCIBus **piommu_bus,
@@ -676,6 +692,7 @@ bool pci_device_set_iommu_device(PCIDevice *dev, HostIOMMUDevice *hiod,
                                  Error **errp);
 void pci_device_unset_iommu_device(PCIDevice *dev);
 AddressSpace *pci_device_iommu_msi_address_space(PCIDevice *dev);
+bool pci_device_iommu_msi_direct_gpa(PCIDevice *dev, hwaddr *out_doorbell);
 
 /**
  * pci_device_get_viommu_flags: get vIOMMU flags.

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -1629,7 +1629,7 @@ int kvm_arm_set_irq(int cpu, int irqtype, int irq, int level)
 int kvm_arch_fixup_msi_route(struct kvm_irq_routing_entry *route,
                              uint64_t address, uint32_t data, PCIDevice *dev)
 {
-    AddressSpace *as = pci_device_iommu_msi_address_space(dev);
+    AddressSpace *as = pci_device_iommu_address_space(dev);
     hwaddr xlat, len, doorbell_gpa;
     MemoryRegionSection mrs;
     MemoryRegion *mr;

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -1638,26 +1638,42 @@ int kvm_arch_fixup_msi_route(struct kvm_irq_routing_entry *route,
         return 0;
     }
 
+    /*
+     * We do have an IOMMU address space, but for some vIOMMU implementations
+     * (e.g. accelerated SMMUv3) the translation tables are programmed into
+     * the physical SMMUv3 in the host (nested S1=guest, S2=host). QEMU cannot
+     * walk these tables in a safe way, so in that case we obtain the MSI
+     * doorbell GPA directly from the vIOMMU backend and ignore the gIOVA
+     * @address.
+     */
+    if (pci_device_iommu_msi_direct_gpa(dev, &doorbell_gpa)) {
+        goto set_doorbell;
+    }
+
     /* MSI doorbell address is translated by an IOMMU */
 
-    RCU_READ_LOCK_GUARD();
+    rcu_read_lock();
 
     mr = address_space_translate(as, address, &xlat, &len, true,
                                  MEMTXATTRS_UNSPECIFIED);
 
     if (!mr) {
+        rcu_read_unlock();
         return 1;
     }
 
     mrs = memory_region_find(mr, xlat, 1);
 
     if (!mrs.mr) {
+        rcu_read_unlock();
         return 1;
     }
 
     doorbell_gpa = mrs.offset_within_address_space;
     memory_region_unref(mrs.mr);
+    rcu_read_unlock();
 
+set_doorbell:
     route->u.msi.address_lo = doorbell_gpa;
     route->u.msi.address_hi = doorbell_gpa >> 32;
 


### PR DESCRIPTION

  ## Summary
  - Backport upstream MSI doorbell GPA patches to fix C_BAD_CD SMMU errors
    in VM with GPU passthrough and `iommu.passthrough=1` (NVBug 6059940)
  - Introduces `get_msi_direct_gpa` PCI IOMMU callback so KVM MSI route
    setup can retrieve the MSI doorbell GPA directly, avoiding unsafe
    software walks of guest translation tables
  - Implements the callback for accelerated SMMUv3 and wires up the
    `msi-gpa` property from the virt machine

  ## Patches
  1. `hw/pci/pci: Introduce a callback to retrieve the MSI doorbell GPA directly`
     (cherry picked from 5c921b29c989)
  2. `hw/arm/smmuv3-accel: Implement get_msi_direct_gpa callback`
     (cherry picked from 3558c85392b6)
  3. `hw/arm/virt: Set msi-gpa property`
     (cherry picked from 5ec2700dcbb0)

  ## Bug
  https://nvbugspro.nvidia.com/bug/6059940
