### PR TITLE
[nvidia_stable-10.1] Backport hw/vfio/iommufd: Control dirty tracking for nesting parent HWPT

### DIFF
--- a/hw/vfio/device.c
+++ b/hw/vfio/device.c
@@ -524,6 +524,17 @@ bool vfio_device_get_viommu_flags_want_nesting(VFIODevice *vbasedev)
     return false;
 }
 
+bool vfio_device_get_viommu_flags_want_nesting_dirty(VFIODevice *vbasedev)
+{
+    VFIOPCIDevice *vdev = vfio_pci_from_vfio_device(vbasedev);
+
+    if (vdev) {
+        return !!(pci_device_get_viommu_flags(&vdev->pdev) &
+                  VIOMMU_FLAG_WANT_NESTING_DIRTY_TRACKING);
+    }
+    return false;
+}
+
 /*
  * Traditional ioctl() based io
  */

--- a/hw/vfio/iommufd.c
+++ b/hw/vfio/iommufd.c
@@ -324,6 +324,7 @@ static bool iommufd_cdev_autodomains_get(VFIODevice *vbasedev,
 {
     ERRP_GUARD();
     IOMMUFDBackend *iommufd = vbasedev->iommufd;
+    bool viommu_nesting, viommu_nesting_dirty;
     uint32_t type = 0, flags = 0;
     uint64_t hw_caps;
     VFIOIOASHwpt *hwpt;
@@ -376,8 +377,14 @@ static bool iommufd_cdev_autodomains_get(VFIODevice *vbasedev,
         return false;
     }
 
+    viommu_nesting = vfio_device_get_viommu_flags_want_nesting(vbasedev);
+    viommu_nesting_dirty =
+        vfio_device_get_viommu_flags_want_nesting_dirty(vbasedev);
+
     if (hw_caps & IOMMU_HW_CAP_DIRTY_TRACKING) {
-        flags = IOMMU_HWPT_ALLOC_DIRTY_TRACKING;
+        if (!viommu_nesting || viommu_nesting_dirty) {
+            flags |= IOMMU_HWPT_ALLOC_DIRTY_TRACKING;
+        }
     }
 
     /*
@@ -385,7 +392,7 @@ static bool iommufd_cdev_autodomains_get(VFIODevice *vbasedev,
      * force to create it so that it could be reused by vIOMMU to create
      * nested HWPT.
      */
-    if (vfio_device_get_viommu_flags_want_nesting(vbasedev)) {
+    if (viommu_nesting) {
         flags |= IOMMU_HWPT_ALLOC_NEST_PARENT;
     }
 

--- a/include/hw/iommu.h
+++ b/include/hw/iommu.h
@@ -15,6 +15,8 @@ enum {
     /* Nesting parent HWPT will be reused by vIOMMU to create nested HWPT */
      VIOMMU_FLAG_WANT_NESTING_PARENT = BIT_ULL(0),
      VIOMMU_FLAG_PASID_SUPPORTED = BIT_ULL(1),
+    /* vIOMMU needs dirty tracking on the nesting parent HWPT for nested use */
+     VIOMMU_FLAG_WANT_NESTING_DIRTY_TRACKING = BIT_ULL(2),
 };
 
 #endif /* HW_IOMMU_H */

--- a/include/hw/vfio/vfio-device.h
+++ b/include/hw/vfio/vfio-device.h
@@ -258,6 +258,7 @@ void vfio_device_prepare(VFIODevice *vbasedev, VFIOContainerBase *bcontainer,
 void vfio_device_unprepare(VFIODevice *vbasedev);
 
 bool vfio_device_get_viommu_flags_want_nesting(VFIODevice *vbasedev);
+bool vfio_device_get_viommu_flags_want_nesting_dirty(VFIODevice *vbasedev);
 
 int vfio_device_get_region_info(VFIODevice *vbasedev, int index,
                                 struct vfio_region_info **info);


### PR DESCRIPTION

  ## Summary
  - Backport hw/vfio/iommufd: Control dirty tracking for nesting parent HWPT to
     fix errors with allocating HWPT (NVBug 6059940)
  - Requesting dirty tracking for a nesting parent HWPT (stage-2) can fail. Add a
     vIOMMU flag to explicitly request dirty tracking for the nesting parent HWPT.
  - This patch was cherry picked from Shameer's branch, where the original
     upstream commit was backported and had some modifications to fit the
     QEMU 10.1 base.

  ## Patch
  1. `hw/vfio/iommufd: Control dirty tracking for nesting parent HWPT`
     (backported from commit 659275f84694)
     (cherry picked from b0e2b946d7c0)

  ## Bug
  https://nvbugspro.nvidia.com/bug/6205284

  ## Testing
  QA can boot VM, install GPU driver, and run RM init using Shameer's branch.
