### PR TITLE
[nvidia_stable-11.0] NVIDIA: SAUCE: WAR: hw/vfio: Retry dma_map to bypass PFNMAP

### DIFF
--- a/hw/vfio/container.c
+++ b/hw/vfio/container.c
@@ -86,8 +86,10 @@ int vfio_container_dma_map(VFIOContainer *bcontainer,
         unsigned long start = vaddr - qemu_ram_get_host_addr(rb);
         unsigned long offset = qemu_ram_get_fd_offset(rb);
 
-        return vioc->dma_map_file(bcontainer, iova, size, mfd, start + offset,
-                                  readonly);
+        if (!vioc->dma_map_file(bcontainer, iova, size, mfd, start + offset,
+                                readonly)) {
+            return 0;
+        }
     }
     g_assert(vioc->dma_map);
     return vioc->dma_map(bcontainer, iova, size, vaddr, readonly, mr);


### PR DESCRIPTION
  ## Summary
EGM uses file-backed guest RAM (/dev/egm*) which selects the vfio_container_dma_map() path in hw/vfio/container.c. When this mapping fails with kernels lacking dmabuf support, return a successful return value to move forward with the bypass PFNMAP WAR in place of dmabuf support: [NVIDIA: SAUCE: WAR: iommufd/pages: Bypass PFNMAP](https://github.com/NVIDIA/NV-Kernels/commit/68a70c30f8ce).

This patch is not required when dmabuf support is present for vEGM.

  ## Testing
Launch 4 GPU EGM VM on GB200 with linux-nvidia 6.17.0-1018-nvidia-64k, verify nvidia-smi and CUDA samples