### PR TITLE
Allow RAM device regions to skip IOMMU mapping 

### DIFF
--- a/hw/vfio/listener.c
+++ b/hw/vfio/listener.c
@@ -598,20 +598,6 @@ void vfio_container_region_add(VFIOContainerBase *bcontainer,
                 pgmask + 1);
             return;
         }
-
-        /*
-         * VFIO MMAP backed regions (CXL.mem) uses VM_IO | VM_PFNMAP VMAs
-         * backed by physical device addresses. Skip vfio_container_dma_map
-         * as mapping is not needed for this region.
-         */
-        if (vfio_get_vfio_device(memory_region_owner(section->mr))) {
-            trace_vfio_listener_region_add_no_dma_map(
-                memory_region_name(section->mr),
-                section->offset_within_address_space,
-                int128_getlo(section->size),
-                pgmask + 1);
-            return;
-        }
     }
 
     ret = vfio_container_dma_map(bcontainer, iova, int128_get64(llsize),


### PR DESCRIPTION
Commit d814a45f76 skipped vfio_container_dma_map for all VFIO-owned
ram-device regions to avoid a fatal hardware error on VR180 (CXL Type-2).
The skip was implemented in vfio_container_region_add() by checking the
region owner, which was too broad: it also silently skipped non-CXL
coherent regions such as NVLink apertures on GB200, breaking ATS because
the nested SMMU S2 HWPT never receives the IOMMU IOAS entry those
regions need.

CXL mmap-backed regions must not be mapped into the IOMMU IOAS.

Fix by marking CXL mmap subregions at creation time in vfio_region_mmap()
using memory_region_set_skip_iommu_map().

Non-CXL VFIO-owned regions are unaffected: their subregions keep the
default skip_iommu_map=false and fall through to vfio_container_dma_map().
