### PR TITLE
test: validate Boro v0.1.1 watcher

### DIFF
--- a/baseos-reviewer-e2e-test.md
+++ b/baseos-reviewer-e2e-test.md
@@ -1,0 +1,3 @@
+# BaseOS reviewer Boro v0.1.1 end-to-end test
+
+Temporary no-op document used to verify the NVIDIA/QEMU watcher with the Boro qemu target after deploying NVIDIA/boro main ff7de21. This draft PR will be closed and its branch deleted after the review artifact is confirmed.


### PR DESCRIPTION
Temporary draft PR for end-to-end BaseOS Reviewer validation after deploying NVIDIA/boro main `ff7de21` (v0.1.1).

- Change: adds one inert Markdown file
- Expected Boro target: `qemu`
- Expected result: watcher queues a review and publishes an artifact
- Cleanup: close this PR and delete the fork branch after verification

No product code is changed.