### PR TITLE
NVIDIA: arm64: add Arm CCA Realm and RME-DA support

### DIFF
--- a/accel/kvm/kvm-all.c
+++ b/accel/kvm/kvm-all.c
@@ -4763,6 +4763,11 @@ void kvm_mark_guest_state_protected(void)
     kvm_state->guest_state_protected = true;
 }
 
+bool kvm_guest_state_protected(void)
+{
+    return kvm_state && kvm_state->guest_state_protected;
+}
+
 int kvm_create_guest_memfd(uint64_t size, uint64_t flags, Error **errp)
 {
     int fd;

--- a/accel/kvm/kvm-all.c
+++ b/accel/kvm/kvm-all.c
@@ -1665,6 +1665,10 @@ static void kvm_set_phys_mem(KVMMemoryListener *kml,
     ram_start_offset = memory_region_get_ram_addr(mr) + mr_offset;
 
     if (!add) {
+        bool clear_attrs = memory_region_is_ram_device(mr) &&
+                           kvm_supported_memory_attributes &
+                               KVM_MEMORY_ATTRIBUTE_PRIVATE;
+
         do {
             slot_size = MIN(kvm_max_slot_size, size);
             mem = kvm_lookup_matching_slot(kml, start_addr, slot_size);
@@ -1707,6 +1711,17 @@ static void kvm_set_phys_mem(KVMMemoryListener *kml,
                 fprintf(stderr, "%s: error unregistering slot: %s\n",
                         __func__, strerror(-err));
                 abort();
+            }
+            /*
+             * Drop any VDEV-installed PRIVATE attributes for this slot. The
+             * mem_attr_array is per-VM and persists across slot lifecycle,
+             * so without this clear a re-mapped or recycled gfn range could
+             * inherit stale VDEV-locked state. The attribute-clear also
+             * tears down any leftover ASSIGNED-DEV S2 entries via
+             * kvm_arch_post_set_memory_attributes() / kvm_unmap_gfn_range().
+             */
+            if (clear_attrs) {
+                kvm_set_memory_attributes_shared(start_addr, slot_size);
             }
             start_addr += slot_size;
             size -= slot_size;
@@ -3379,16 +3394,40 @@ int kvm_convert_memory(hwaddr start, hwaddr size, bool to_private)
 
     if (!memory_region_has_guest_memfd(mr)) {
         /*
-         * Because vMMIO region must be shared, guest TD may convert vMMIO
-         * region to shared explicitly.  Don't complain such case.  See
+         * Because vMMIO region may be shared, guest TD may convert vMMIO
+         * region to shared explicitly. Don't complain such case. See
          * memory_region_type() for checking if the region is MMIO region.
          */
         if (!to_private &&
-            !memory_region_is_ram(mr) &&
-            !memory_region_is_ram_device(mr) &&
+            (!memory_region_is_ram(mr) ||
+             memory_region_is_ram_device(mr)) &&
             !memory_region_is_rom(mr) &&
             !memory_region_is_romd(mr)) {
-            ret = 0;
+            /*
+             * For ram_device regions (e.g. VFIO BARs), the realm may
+             * have marked individual gfns PRIVATE through
+             * iommufd_tsm_dev_memmap_exit() when validating a VDEV
+             * mapping. When the realm later asks to release the
+             * mapping with RSI_IPA_STATE_SET(EMPTY), the kernel
+             * surfaces it here as a !to_private convert. A silent
+             * ret=0 would leave PRIVATE set with no DEV mapping
+             * behind it; honour the release by actually clearing the
+             * attribute. The kvm_arch_post_set_memory_attributes()
+             * side-effect then tears down any leftover ASSIGNED-DEV
+             * S2 via kvm_unmap_gfn_range(KVM_FILTER_PRIVATE), keeping
+             * userspace's view in sync with the kernel's.
+             *
+             * For the non-ram_device legs of this branch (e.g. TDX
+             * vMMIO traps) no PRIVATE attribute was ever installed,
+             * so preserve the original ret=0 fast path.
+             */
+            if (memory_region_is_ram_device(mr) &&
+                (kvm_supported_memory_attributes &
+                 KVM_MEMORY_ATTRIBUTE_PRIVATE)) {
+                ret = kvm_set_memory_attributes_shared(start, size);
+            } else {
+                ret = 0;
+            }
         } else {
             error_report("Convert non guest_memfd backed memory region "
                         "(0x%"HWADDR_PRIx" ,+ 0x%"HWADDR_PRIx") to %s",

--- a/accel/stubs/kvm-stub.c
+++ b/accel/stubs/kvm-stub.c
@@ -143,3 +143,13 @@ int kvm_create_guest_memfd(uint64_t size, uint64_t flags, Error **errp)
 {
     return -ENOSYS;
 }
+
+int kvm_set_memory_attributes_private(hwaddr start, uint64_t size)
+{
+    return -ENOSYS;
+}
+
+int kvm_set_memory_attributes_shared(hwaddr start, uint64_t size)
+{
+    return -ENOSYS;
+}

--- a/docs/interop/firmware.json
+++ b/docs/interop/firmware.json
@@ -161,6 +161,9 @@
 #     options related to this feature are documented in
 #     "docs/system/i386/amd-memory-encryption.rst".
 #
+# @arm-rme: The firmware supports running in a Realm, under the Arm
+#     Realm Management Extension (RME).
+#
 # @intel-tdx: The firmware supports running under Intel Trust Domain
 #     Extensions (TDX).
 #
@@ -229,7 +232,7 @@
 { 'enum' : 'FirmwareFeature',
   'data' : [ 'acpi-s3', 'acpi-s4',
              'amd-sev', 'amd-sev-es', 'amd-sev-snp',
-             'intel-tdx',
+             'arm-rme', 'intel-tdx',
              'enrolled-keys', 'requires-smm',
              'secure-boot', 'host-uefi-vars',
              'verbose-dynamic', 'verbose-static' ] }

--- a/docs/system/arm/virt.rst
+++ b/docs/system/arm/virt.rst
@@ -218,10 +218,11 @@ dtb-randomness
   rng-seed and kaslr-seed nodes (in both "/chosen" and
   "/secure-chosen") to use for features like the random number
   generator and address space randomisation. The default is
-  ``on``. You will want to disable it if your trusted boot chain
-  will verify the DTB it is passed, since this option causes the
-  DTB to be non-deterministic. It would be the responsibility of
-  the firmware to come up with a seed and pass it on if it wants to.
+  ``off`` for confidential VMs, and ``on`` otherwise. You will want
+  to disable it if your trusted boot chain will verify the DTB it is
+  passed, since this option causes the DTB to be non-deterministic.
+  It would be the responsibility of the firmware to come up with a
+  seed and pass it on if it wants to.
 
 dtb-kaslr-seed
   A deprecated synonym for dtb-randomness.

--- a/docs/system/confidential-guest-support.rst
+++ b/docs/system/confidential-guest-support.rst
@@ -42,5 +42,6 @@ Currently supported confidential guest mechanisms are:
 * POWER Protected Execution Facility (PEF) (see :ref:`power-papr-protected-execution-facility-pef`)
 * s390x Protected Virtualization (PV) (see :doc:`s390x/protvirt`)
 * AWS Nitro Enclaves (see :doc:`nitro`)
+* Arm Realm Management Extension (RME)
 
 Other mechanisms may be supported in future.

--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -1222,7 +1222,36 @@ static void arm_setup_direct_kernel_boot(ARMCPU *cpu,
     }
 }
 
-static void arm_setup_firmware_boot(ARMCPU *cpu, struct arm_boot_info *info)
+static void arm_setup_confidential_firmware_boot(ARMCPU *cpu,
+                                                 struct arm_boot_info *info,
+                                                 const char *firmware_filename)
+{
+    ssize_t fw_size;
+    const char *fname;
+    AddressSpace *as = arm_boot_address_space(cpu, info);
+
+    fname = qemu_find_file(QEMU_FILE_TYPE_BIOS, firmware_filename);
+    if (!fname) {
+        error_report("Could not find firmware image '%s'", firmware_filename);
+        exit(1);
+    }
+
+    /*
+     * Load the firmware image in the Realm's address space.  Mapping of the
+     * firmware area in the Realm's address space is done in function
+     * virt_confidential_firmware_init().
+     */
+    fw_size = load_image_targphys_as(firmware_filename,
+                                     info->firmware_base,
+                                     info->firmware_max_size, as, NULL);
+    if (fw_size <= 0) {
+        error_report("could not load firmware '%s'", firmware_filename);
+        exit(1);
+    }
+}
+
+static void arm_setup_firmware_boot(ARMCPU *cpu, struct arm_boot_info *info,
+                                    const char *firmware_filename)
 {
     /* Set up for booting firmware (which might load a kernel via fw_cfg) */
 
@@ -1273,6 +1302,10 @@ static void arm_setup_firmware_boot(ARMCPU *cpu, struct arm_boot_info *info)
         }
     }
 
+    if (info->confidential) {
+        arm_setup_confidential_firmware_boot(cpu, info, firmware_filename);
+    }
+
     /*
      * We will start from address 0 (typically a boot ROM image) in the
      * same way as hardware. Leave env->boot_info NULL, so that
@@ -1316,7 +1349,7 @@ void arm_load_kernel(ARMCPU *cpu, MachineState *ms, struct arm_boot_info *info)
 
     /* Load the kernel.  */
     if (!info->kernel_filename || info->firmware_loaded) {
-        arm_setup_firmware_boot(cpu, info);
+        arm_setup_firmware_boot(cpu, info, ms->firmware);
     } else {
         arm_setup_direct_kernel_boot(cpu, info);
     }

--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -581,7 +581,14 @@ int arm_load_dtb(hwaddr addr, const struct arm_boot_info *binfo,
     g_autoptr(MemoryDeviceInfoList) md_list = NULL;
     Error *err = NULL;
 
-    if (binfo->dtb_filename) {
+    if (binfo->dtb_filename && binfo->confidential) {
+        /*
+         * If the user is providing a DTB for a confidential VM, it is already
+         * tailored to this configuration and measured. Load it as is, without
+         * any modification.
+         */
+        return rom_add_file_fixed_as(binfo->dtb_filename, addr, -1, as);
+    } else if (binfo->dtb_filename) {
         char *filename;
         filename = qemu_find_file(QEMU_FILE_TYPE_DTB, binfo->dtb_filename);
         if (!filename) {

--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -1249,6 +1249,12 @@ static void arm_setup_confidential_firmware_boot(ARMCPU *cpu,
     g_autofree char *fname = NULL;
     AddressSpace *as = arm_boot_address_space(cpu, info);
 
+    if (!firmware_filename) {
+        error_report("a confidential Arm guest requires either a kernel "
+                     "or a firmware image");
+        exit(1);
+    }
+
     fname = qemu_find_file(QEMU_FILE_TYPE_BIOS, firmware_filename);
     if (!fname) {
         error_report("Could not find firmware image '%s'", firmware_filename);

--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -841,7 +841,13 @@ static void do_cpu_reset(void *opaque)
             if (cpu == info->primary_cpu) {
                 AddressSpace *as = arm_boot_address_space(cpu, info);
 
-                cpu_set_pc(cs, info->loader_start);
+                if (info->confidential)  {
+                    assert(is_a64(env));
+                    env->xregs[0] = info->dtb_start;
+                    cpu_set_pc(cs, info->entry);
+                } else {
+                    cpu_set_pc(cs, info->loader_start);
+                }
 
                 if (!have_dtb(info)) {
                     set_kernel_args(info, as);
@@ -931,7 +937,8 @@ static ssize_t arm_load_elf(struct arm_boot_info *info, uint64_t *pentry,
 }
 
 static uint64_t load_aarch64_image(const char *filename, hwaddr mem_base,
-                                   hwaddr *entry, AddressSpace *as)
+                                   hwaddr *entry, AddressSpace *as,
+                                   bool confidential)
 {
     const size_t max_bytes = LOAD_IMAGE_MAX_DECOMPRESSED_BYTES;
     hwaddr kernel_load_offset = KERNEL64_LOAD_ADDR;
@@ -983,7 +990,8 @@ static uint64_t load_aarch64_image(const char *filename, hwaddr mem_base,
              * bootloader, we can just load it starting at 2MB+offset rather
              * than 0MB + offset.
              */
-            if (kernel_load_offset < BOOTLOADER_MAX_SIZE) {
+            if (kernel_load_offset < BOOTLOADER_MAX_SIZE &&
+                !confidential) {
                 kernel_load_offset += 2 * MiB;
             }
         }
@@ -1067,7 +1075,8 @@ static void arm_setup_direct_kernel_boot(ARMCPU *cpu,
     }
     if (arm_feature(&cpu->env, ARM_FEATURE_AARCH64) && kernel_size < 0) {
         kernel_size = load_aarch64_image(info->kernel_filename,
-                                         info->loader_start, &entry, as);
+                                         info->loader_start, &entry, as,
+                                         info->confidential);
         is_linux = 1;
         if (kernel_size >= 0) {
             image_low_addr = entry;
@@ -1208,8 +1217,11 @@ static void arm_setup_direct_kernel_boot(ARMCPU *cpu,
         fixupcontext[FIXUP_ENTRYPOINT_LO] = entry;
         fixupcontext[FIXUP_ENTRYPOINT_HI] = entry >> 32;
 
-        arm_write_bootloader("bootloader", as, info->loader_start,
-                             primary_loader, fixupcontext);
+        /* Immediately jump to the kernel when guest is a Realm */
+        if (!info->confidential) {
+            arm_write_bootloader("bootloader", as, info->loader_start,
+                                 primary_loader, fixupcontext);
+        }
 
         if (info->write_board_setup) {
             info->write_board_setup(cpu, info);

--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -582,12 +582,40 @@ int arm_load_dtb(hwaddr addr, const struct arm_boot_info *binfo,
     Error *err = NULL;
 
     if (binfo->dtb_filename && binfo->confidential) {
+        g_autofree char *filename = NULL;
+        int64_t file_size;
+
         /*
          * If the user is providing a DTB for a confidential VM, it is already
          * tailored to this configuration and measured. Load it as is, without
          * any modification.
          */
-        return rom_add_file_fixed_as(binfo->dtb_filename, addr, -1, as);
+        filename = qemu_find_file(QEMU_FILE_TYPE_DTB, binfo->dtb_filename);
+        if (!filename) {
+            fprintf(stderr, "Couldn't open dtb file %s\n",
+                    binfo->dtb_filename);
+            goto fail;
+        }
+
+        file_size = get_image_size(filename, &err);
+        if (file_size <= 0 || file_size > INT_MAX) {
+            if (err) {
+                error_report_err(err);
+                err = NULL;
+            } else {
+                error_report("Invalid DTB file size for %s", filename);
+            }
+            goto fail;
+        }
+
+        if (addr_limit > addr && file_size > addr_limit - addr) {
+            return 0;
+        }
+
+        if (rom_add_file_fixed_as(filename, addr, -1, as) < 0) {
+            goto fail;
+        }
+        return file_size;
     } else if (binfo->dtb_filename) {
         char *filename;
         filename = qemu_find_file(QEMU_FILE_TYPE_DTB, binfo->dtb_filename);

--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -1246,7 +1246,7 @@ static void arm_setup_confidential_firmware_boot(ARMCPU *cpu,
                                                  const char *firmware_filename)
 {
     ssize_t fw_size;
-    const char *fname;
+    g_autofree char *fname = NULL;
     AddressSpace *as = arm_boot_address_space(cpu, info);
 
     fname = qemu_find_file(QEMU_FILE_TYPE_BIOS, firmware_filename);
@@ -1260,8 +1260,7 @@ static void arm_setup_confidential_firmware_boot(ARMCPU *cpu,
      * firmware area in the Realm's address space is done in function
      * virt_confidential_firmware_init().
      */
-    fw_size = load_image_targphys_as(firmware_filename,
-                                     info->firmware_base,
+    fw_size = load_image_targphys_as(fname, info->firmware_base,
                                      info->firmware_max_size, as, NULL);
     if (fw_size <= 0) {
         error_report("could not load firmware '%s'", firmware_filename);

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -2382,6 +2382,11 @@ static void machvirt_init(MachineState *machine)
     unsigned int smp_cpus = machine->smp.cpus;
     unsigned int max_cpus = machine->smp.max_cpus;
 
+    if (virt_machine_is_confidential(vms) && vms->iommu != VIRT_IOMMU_NONE) {
+        error_report("guest IOMMUs are not supported for Realm VMs");
+        exit(EXIT_FAILURE);
+    }
+
     virt_flash_create(vms);
 
     possible_cpus = mc->possible_cpu_arch_ids(machine);
@@ -3272,6 +3277,13 @@ static void virt_machine_device_pre_plug_cb(HotplugHandler *hotplug_dev,
                                             DeviceState *dev, Error **errp)
 {
     VirtMachineState *vms = VIRT_MACHINE(hotplug_dev);
+
+    if (virt_machine_is_confidential(vms) &&
+        (object_dynamic_cast(OBJECT(dev), TYPE_VIRTIO_IOMMU_PCI) ||
+         object_dynamic_cast(OBJECT(dev), TYPE_ARM_SMMUV3))) {
+        error_setg(errp, "guest IOMMUs are not supported for Realm VMs");
+        return;
+    }
 
     if (object_dynamic_cast(OBJECT(dev), TYPE_PC_DIMM)) {
         virt_memory_pre_plug(hotplug_dev, dev, errp);

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -1298,6 +1298,16 @@ static PFlashCFI01 *virt_flash_create1(VirtMachineState *vms,
 
 static void virt_flash_create(VirtMachineState *vms)
 {
+    /*
+     * For Realms, the firmware image is placed directly in the guest's
+     * RAM area.  The association between the final location in the
+     * guest's RAM and the system memory is done in function
+     * virt_confidential_firmware_init().
+     */
+    if (virt_machine_is_confidential(vms)) {
+        return;
+    }
+
     vms->flash[0] = virt_flash_create1(vms, "virt.flash0", "pflash0");
     vms->flash[1] = virt_flash_create1(vms, "virt.flash1", "pflash1");
 }
@@ -1348,6 +1358,16 @@ static void virt_flash_fdt(VirtMachineState *vms,
     MachineState *ms = MACHINE(vms);
     char *nodename;
 
+    /*
+     * For Realms the firmware images are stored in the guest's address
+     * space.  As such there is no need for flash configuration in the FDT.
+     * See function virt_confidential_firmware_init() and
+     * arm_setup_confidential_firmware_boot() for details.
+     */
+    if (virt_machine_is_confidential(vms)) {
+        return;
+    }
+
     if (sysmem == secure_sysmem) {
         /* Report both flash devices as a single node in the DT */
         nodename = g_strdup_printf("/flash@%" PRIx64, flashbase);
@@ -1383,6 +1403,32 @@ static void virt_flash_fdt(VirtMachineState *vms,
     }
 }
 
+static bool virt_confidential_firmware_init(VirtMachineState *vms,
+                                            MemoryRegion *sysmem)
+{
+    MemoryRegion *fw_ram;
+    hwaddr fw_base = vms->memmap[VIRT_FLASH].base;
+    hwaddr fw_size = vms->memmap[VIRT_FLASH].size;
+
+    if (!MACHINE(vms)->firmware) {
+        return false;
+    }
+
+    assert(machine_require_guest_memfd(MACHINE(vms)));
+
+    fw_ram = g_new(MemoryRegion, 1);
+    memory_region_init_ram_guest_memfd(fw_ram, NULL, "fw_ram", fw_size,
+                                       &error_fatal);
+    /*
+     * Map the guest's firmware image directly in its address space.
+     * Copying of the firmware image itself is done in function
+     * arm_setup_confidential_firmware_boot().
+     */
+    memory_region_add_subregion(sysmem, fw_base, fw_ram);
+
+    return true;
+}
+
 static bool virt_firmware_init(VirtMachineState *vms,
                                MemoryRegion *sysmem,
                                MemoryRegion *secure_sysmem)
@@ -1390,6 +1436,15 @@ static bool virt_firmware_init(VirtMachineState *vms,
     int i;
     const char *bios_name;
     BlockBackend *pflash_blk0;
+
+    /*
+     * For a confidential VM, the firmware image and any boot information,
+     * including EFI variables, are stored in RAM in order to be measurable and
+     * private. Create a RAM region and load the firmware image there.
+     */
+    if (virt_machine_is_confidential(vms)) {
+        return virt_confidential_firmware_init(vms, sysmem);
+    }
 
     /* Map legacy -drive if=pflash to machine properties */
     for (i = 0; i < ARRAY_SIZE(vms->flash); i++) {
@@ -2671,7 +2726,10 @@ static void machvirt_init(MachineState *machine)
     vms->bootinfo.get_dtb = machvirt_dtb;
     vms->bootinfo.skip_dtb_autoload = true;
     vms->bootinfo.firmware_loaded = firmware_loaded;
+    vms->bootinfo.firmware_base = vms->memmap[VIRT_FLASH].base;
+    vms->bootinfo.firmware_max_size = vms->memmap[VIRT_FLASH].size;
     vms->bootinfo.psci_conduit = vms->psci_conduit;
+    vms->bootinfo.confidential = virt_machine_is_confidential(vms);
     arm_load_kernel(ARM_CPU(first_cpu), machine, &vms->bootinfo);
 
     vms->machine_done.notify = virt_machine_done;

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -2327,6 +2327,8 @@ static void machvirt_init(MachineState *machine)
     unsigned int smp_cpus = machine->smp.cpus;
     unsigned int max_cpus = machine->smp.max_cpus;
 
+    virt_flash_create(vms);
+
     possible_cpus = mc->possible_cpu_arch_ids(machine);
 
     /*
@@ -3775,8 +3777,6 @@ static void virt_instance_init(Object *obj)
     vms->irqmap = a15irqmap;
 
     vms->virtio_transports = NUM_VIRTIO_TRANSPORTS;
-
-    virt_flash_create(vms);
 
     vms->oem_id = g_strndup(ACPI_BUILD_APPNAME6, 6);
     vms->oem_table_id = g_strndup(ACPI_BUILD_APPNAME8, 8);

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -1741,6 +1741,13 @@ static void create_pcie(VirtMachineState *vms)
     pci->bypass_iommu = vms->default_bus_bypass_iommu;
     vms->bus = pci->bus;
     if (vms->bus) {
+        /*
+         * PCI devices cache their DMA address space when they are realized.
+         * Install the Realm DMA address-space selector before creating even
+         * the default NIC, otherwise those devices bypass the shared-IPA
+         * translation permanently.
+         */
+        kvm_arm_rme_init_gpa_space(vms->highest_gpa, vms->bus);
         pci_init_nic_devices(pci->bus, mc->default_nic);
     }
 
@@ -2391,6 +2398,13 @@ static void machvirt_init(MachineState *machine)
         exit(EXIT_FAILURE);
     }
 
+    if (virt_machine_is_confidential(vms) &&
+        vms->default_bus_bypass_iommu) {
+        error_report("default-bus-bypass-iommu is not supported for Realm "
+                     "VMs");
+        exit(EXIT_FAILURE);
+    }
+
     virt_flash_create(vms);
 
     possible_cpus = mc->possible_cpu_arch_ids(machine);
@@ -2728,8 +2742,6 @@ static void machvirt_init(MachineState *machine)
                                arm_virt_nvdimm_acpi_dsmio,
                                vms->fw_cfg, OBJECT(vms));
     }
-
-    kvm_arm_rme_init_gpa_space(vms->highest_gpa, vms->bus);
 
     vms->bootinfo.ram_size = machine->ram_size;
     vms->bootinfo.board_id = -1;

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -2720,6 +2720,8 @@ static void machvirt_init(MachineState *machine)
                                vms->fw_cfg, OBJECT(vms));
     }
 
+    kvm_arm_rme_init_gpa_space(vms->highest_gpa, vms->bus);
+
     vms->bootinfo.ram_size = machine->ram_size;
     vms->bootinfo.board_id = -1;
     vms->bootinfo.loader_start = vms->memmap[VIRT_MEM].base;

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -263,6 +263,11 @@ static const int a15irqmap[] = {
     [VIRT_PLATFORM_BUS] = 112, /* ...to 112 + PLATFORM_BUS_NUM_IRQS -1 */
 };
 
+static bool virt_machine_is_confidential(VirtMachineState *vms)
+{
+    return MACHINE(vms)->cgs;
+}
+
 static void create_randomness(MachineState *ms, const char *node)
 {
     struct {
@@ -2368,10 +2373,11 @@ static void machvirt_init(MachineState *machine)
      * if the guest has EL2 then we will use SMC as the conduit,
      * and otherwise we will use HVC (for backwards compatibility and
      * because if we're using KVM then we must use HVC).
+     * Realm guests must also use SMC.
      */
     if (vms->secure && firmware_loaded) {
         vms->psci_conduit = QEMU_PSCI_CONDUIT_DISABLED;
-    } else if (vms->virt) {
+    } else if (vms->virt || virt_machine_is_confidential(vms)) {
         vms->psci_conduit = QEMU_PSCI_CONDUIT_SMC;
     } else {
         vms->psci_conduit = QEMU_PSCI_CONDUIT_HVC;

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -3416,17 +3416,27 @@ static int virt_kvm_type(MachineState *ms, const char *type_str)
 {
     VirtMachineState *vms = VIRT_MACHINE(ms);
     int max_vm_pa_size, requested_pa_size;
+    int rme_reserve_bit = 0;
     bool fixed_ipa;
     int vm_type;
 
-    max_vm_pa_size = kvm_arm_get_max_vm_ipa_size(ms, &fixed_ipa);
-
     vm_type = (ms->cgs ? KVM_VM_TYPE_ARM_REALM : KVM_VM_TYPE_ARM_NORMAL);
+
+    if (vm_type) {
+        /*
+         * With RME, the upper GPA bit differentiates Realm from NS memory.
+         * Reserve the upper bit to ensure that highmem devices will fit.
+         */
+        rme_reserve_bit = 1;
+    }
+
+    max_vm_pa_size = kvm_arm_get_max_vm_ipa_size(ms, &fixed_ipa) -
+                     rme_reserve_bit;
 
     /* we freeze the memory map to compute the highest gpa */
     virt_set_memmap(vms, max_vm_pa_size);
 
-    requested_pa_size = 64 - clz64(vms->highest_gpa);
+    requested_pa_size = 64 - clz64(vms->highest_gpa) + rme_reserve_bit;
 
     /*
      * KVM requires the IPA size to be at least 32 bits.
@@ -3435,11 +3445,11 @@ static int virt_kvm_type(MachineState *ms, const char *type_str)
         requested_pa_size = 32;
     }
 
-    if (requested_pa_size > max_vm_pa_size) {
+    if (requested_pa_size > max_vm_pa_size + rme_reserve_bit) {
         error_report("-m and ,maxmem option values "
                      "require an IPA range (%d bits) larger than "
                      "the one supported by the host (%d bits)",
-                     requested_pa_size, max_vm_pa_size);
+                     requested_pa_size, max_vm_pa_size + rme_reserve_bit);
         return -1;
     }
     /*

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -62,6 +62,7 @@
 #include "hw/pci-host/gpex.h"
 #include "hw/pci-bridge/pci_expander_bridge.h"
 #include "hw/virtio/virtio-pci.h"
+#include "hw/virtio/virtio-mmio.h"
 #include "hw/core/sysbus-fdt.h"
 #include "hw/core/platform-bus.h"
 #include "hw/core/qdev-properties.h"
@@ -1208,6 +1209,7 @@ static void create_gpio_devices(const VirtMachineState *vms, int gpio,
 
 static void create_virtio_devices(const VirtMachineState *vms)
 {
+    AddressSpace *dma_as = kvm_arm_rme_get_dma_as();
     int i;
     hwaddr size = vms->memmap[VIRT_MMIO].size;
     MachineState *ms = MACHINE(vms);
@@ -1242,9 +1244,18 @@ static void create_virtio_devices(const VirtMachineState *vms)
     for (i = 0; i < vms->virtio_transports; i++) {
         int irq = vms->irqmap[VIRT_MMIO] + i;
         hwaddr base = vms->memmap[VIRT_MMIO].base + i * size;
+        DeviceState *dev = qdev_new(TYPE_VIRTIO_MMIO);
+        SysBusDevice *s = SYS_BUS_DEVICE(dev);
 
-        sysbus_create_simple("virtio-mmio", base,
-                             qdev_get_gpio_in(vms->gic, irq));
+        if (dma_as) {
+            /* Legacy virtio-mmio cannot negotiate IOMMU_PLATFORM. */
+            qdev_prop_set_bit(dev, "force-legacy", false);
+            virtio_mmio_set_dma_as(dev, dma_as);
+        }
+
+        sysbus_realize_and_unref(s, &error_fatal);
+        sysbus_mmio_map(s, 0, base);
+        sysbus_connect_irq(s, 0, qdev_get_gpio_in(vms->gic, irq));
     }
 
     /* We add dtb nodes in reverse order so that they appear in the finished
@@ -1742,10 +1753,9 @@ static void create_pcie(VirtMachineState *vms)
     vms->bus = pci->bus;
     if (vms->bus) {
         /*
-         * PCI devices cache their DMA address space when they are realized.
-         * Install the Realm DMA address-space selector before creating even
-         * the default NIC, otherwise those devices bypass the shared-IPA
-         * translation permanently.
+         * Some PCI devices query their IOMMU address space while they are
+         * realized. Install the Realm DMA address-space selector before
+         * creating even the default NIC so every endpoint sees it.
          */
         kvm_arm_rme_init_gpa_space(vms->highest_gpa, vms->bus);
         pci_init_nic_devices(pci->bus, mc->default_nic);
@@ -2726,7 +2736,8 @@ static void machvirt_init(MachineState *machine)
      */
     create_virtio_devices(vms);
 
-    vms->fw_cfg = create_fw_cfg(vms, &address_space_memory);
+    vms->fw_cfg = create_fw_cfg(vms, kvm_arm_rme_get_dma_as() ?:
+                                     &address_space_memory);
     rom_set_fw(vms->fw_cfg);
 
     create_platform_bus(vms);

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -95,6 +95,8 @@
 #include "hw/cxl/cxl_host.h"
 #include "qemu/guest-random.h"
 
+#include <linux/kvm.h>
+
 static GlobalProperty arm_virt_compat_defaults[] = {
     { TYPE_VIRTIO_IOMMU_PCI, "aw-bits", "48" },
 };
@@ -3415,8 +3417,11 @@ static int virt_kvm_type(MachineState *ms, const char *type_str)
     VirtMachineState *vms = VIRT_MACHINE(ms);
     int max_vm_pa_size, requested_pa_size;
     bool fixed_ipa;
+    int vm_type;
 
     max_vm_pa_size = kvm_arm_get_max_vm_ipa_size(ms, &fixed_ipa);
+
+    vm_type = (ms->cgs ? KVM_VM_TYPE_ARM_REALM : KVM_VM_TYPE_ARM_NORMAL);
 
     /* we freeze the memory map to compute the highest gpa */
     virt_set_memmap(vms, max_vm_pa_size);
@@ -3442,7 +3447,11 @@ static int virt_kvm_type(MachineState *ms, const char *type_str)
      * the implicit legacy 40b IPA setting, in which case the kvm_type
      * must be 0.
      */
-    return fixed_ipa ? 0 : requested_pa_size;
+    if (fixed_ipa) {
+        return 0;
+    }
+
+    return requested_pa_size | vm_type;
 }
 
 static int virt_get_physical_address_range(MachineState *ms,

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -3546,7 +3546,7 @@ static int virt_kvm_type(MachineState *ms, const char *type_str)
      * must be 0.
      */
     if (fixed_ipa) {
-        return 0;
+        return vm_type;
     }
 
     return requested_pa_size | vm_type;

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -270,6 +270,12 @@ static bool virt_machine_is_confidential(VirtMachineState *vms)
     return MACHINE(vms)->cgs;
 }
 
+static bool virt_dtb_randomness_enabled(VirtMachineState *vms)
+{
+    return vms->dtb_randomness &&
+           (vms->dtb_randomness_set || !virt_machine_is_confidential(vms));
+}
+
 static void create_randomness(MachineState *ms, const char *node)
 {
     struct {
@@ -314,9 +320,7 @@ static void create_fdt(VirtMachineState *vms)
      * Including random data in the DTB causes random intial measurement on CCA,
      * so disable it for confidential VMs.
      */
-    if (vms->dtb_randomness == ON_OFF_AUTO_OFF ||
-        (vms->dtb_randomness == ON_OFF_AUTO_AUTO &&
-         virt_machine_is_confidential(vms))) {
+    if (!virt_dtb_randomness_enabled(vms)) {
         dtb_randomness = false;
     }
 
@@ -2979,21 +2983,19 @@ static void virt_set_virtio_transports(Object *obj, Visitor *v,
     vms->virtio_transports = transports;
 }
 
-static void virt_get_dtb_randomness(Object *obj, Visitor *v, const char *name,
-                                    void *opaque, Error **errp)
+static bool virt_get_dtb_randomness(Object *obj, Error **errp)
 {
     VirtMachineState *vms = VIRT_MACHINE(obj);
-    OnOffAuto dtb_randomness = vms->dtb_randomness;
 
-    visit_type_OnOffAuto(v, name, &dtb_randomness, errp);
+    return virt_dtb_randomness_enabled(vms);
 }
 
-static void virt_set_dtb_randomness(Object *obj, Visitor *v, const char *name,
-                                    void *opaque, Error **errp)
+static void virt_set_dtb_randomness(Object *obj, bool value, Error **errp)
 {
     VirtMachineState *vms = VIRT_MACHINE(obj);
 
-    visit_type_OnOffAuto(v, name, &vms->dtb_randomness, errp);
+    vms->dtb_randomness = value;
+    vms->dtb_randomness_set = true;
 }
 
 static char *virt_get_oem_id(Object *obj, Error **errp)
@@ -3774,16 +3776,16 @@ static void virt_machine_class_init(ObjectClass *oc, const void *data)
                                           "Set MSI settings. "
                                           "Valid values are auto, gicv2m, its and off");
 
-    object_class_property_add(oc, "dtb-randomness", "OnOffAuto",
-                              virt_get_dtb_randomness, virt_set_dtb_randomness,
-                              NULL, NULL);
+    object_class_property_add_bool(oc, "dtb-randomness",
+                                   virt_get_dtb_randomness,
+                                   virt_set_dtb_randomness);
     object_class_property_set_description(oc, "dtb-randomness",
                                           "Set off to disable passing random or "
                                           "non-deterministic dtb nodes to guest");
 
-    object_class_property_add(oc, "dtb-kaslr-seed", "OnOffAuto",
-                              virt_get_dtb_randomness, virt_set_dtb_randomness,
-                              NULL, NULL);
+    object_class_property_add_bool(oc, "dtb-kaslr-seed",
+                                   virt_get_dtb_randomness,
+                                   virt_set_dtb_randomness);
     object_class_property_set_description(oc, "dtb-kaslr-seed",
                                           "Deprecated synonym of dtb-randomness");
 
@@ -3845,6 +3847,9 @@ static void virt_instance_init(Object *obj)
 
     /* MTE is disabled by default.  */
     vms->mte = false;
+
+    /* Supply kaslr-seed and rng-seed by default. */
+    vms->dtb_randomness = true;
 
     vms->irqmap = a15irqmap;
 

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -300,6 +300,7 @@ static bool ns_el2_virt_timer_present(void)
 
 static void create_fdt(VirtMachineState *vms)
 {
+    bool dtb_randomness = true;
     MachineState *ms = MACHINE(vms);
     int nb_numa_nodes = ms->numa_state->num_nodes;
     void *fdt = create_device_tree(&vms->fdt_size);
@@ -307,6 +308,16 @@ static void create_fdt(VirtMachineState *vms)
     if (!fdt) {
         error_report("create_device_tree() failed");
         exit(1);
+    }
+
+    /*
+     * Including random data in the DTB causes random intial measurement on CCA,
+     * so disable it for confidential VMs.
+     */
+    if (vms->dtb_randomness == ON_OFF_AUTO_OFF ||
+        (vms->dtb_randomness == ON_OFF_AUTO_AUTO &&
+         virt_machine_is_confidential(vms))) {
+        dtb_randomness = false;
     }
 
     ms->fdt = fdt;
@@ -330,13 +341,13 @@ static void create_fdt(VirtMachineState *vms)
 
     /* /chosen must exist for load_dtb to fill in necessary properties later */
     qemu_fdt_add_subnode(fdt, "/chosen");
-    if (vms->dtb_randomness) {
+    if (dtb_randomness) {
         create_randomness(ms, "/chosen");
     }
 
     if (vms->secure) {
         qemu_fdt_add_subnode(fdt, "/secure-chosen");
-        if (vms->dtb_randomness) {
+        if (dtb_randomness) {
             create_randomness(ms, "/secure-chosen");
         }
     }
@@ -2901,18 +2912,21 @@ static void virt_set_virtio_transports(Object *obj, Visitor *v,
     vms->virtio_transports = transports;
 }
 
-static bool virt_get_dtb_randomness(Object *obj, Error **errp)
+static void virt_get_dtb_randomness(Object *obj, Visitor *v, const char *name,
+                                    void *opaque, Error **errp)
 {
     VirtMachineState *vms = VIRT_MACHINE(obj);
+    OnOffAuto dtb_randomness = vms->dtb_randomness;
 
-    return vms->dtb_randomness;
+    visit_type_OnOffAuto(v, name, &dtb_randomness, errp);
 }
 
-static void virt_set_dtb_randomness(Object *obj, bool value, Error **errp)
+static void virt_set_dtb_randomness(Object *obj, Visitor *v, const char *name,
+                                    void *opaque, Error **errp)
 {
     VirtMachineState *vms = VIRT_MACHINE(obj);
 
-    vms->dtb_randomness = value;
+    visit_type_OnOffAuto(v, name, &vms->dtb_randomness, errp);
 }
 
 static char *virt_get_oem_id(Object *obj, Error **errp)
@@ -3686,16 +3700,16 @@ static void virt_machine_class_init(ObjectClass *oc, const void *data)
                                           "Set MSI settings. "
                                           "Valid values are auto, gicv2m, its and off");
 
-    object_class_property_add_bool(oc, "dtb-randomness",
-                                   virt_get_dtb_randomness,
-                                   virt_set_dtb_randomness);
+    object_class_property_add(oc, "dtb-randomness", "OnOffAuto",
+                              virt_get_dtb_randomness, virt_set_dtb_randomness,
+                              NULL, NULL);
     object_class_property_set_description(oc, "dtb-randomness",
                                           "Set off to disable passing random or "
                                           "non-deterministic dtb nodes to guest");
 
-    object_class_property_add_bool(oc, "dtb-kaslr-seed",
-                                   virt_get_dtb_randomness,
-                                   virt_set_dtb_randomness);
+    object_class_property_add(oc, "dtb-kaslr-seed", "OnOffAuto",
+                              virt_get_dtb_randomness, virt_set_dtb_randomness,
+                              NULL, NULL);
     object_class_property_set_description(oc, "dtb-kaslr-seed",
                                           "Deprecated synonym of dtb-randomness");
 
@@ -3757,9 +3771,6 @@ static void virt_instance_init(Object *obj)
 
     /* MTE is disabled by default.  */
     vms->mte = false;
-
-    /* Supply kaslr-seed and rng-seed by default */
-    vms->dtb_randomness = true;
 
     vms->irqmap = a15irqmap;
 

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -3010,7 +3010,12 @@ static bool virt_get_dtb_randomness(Object *obj, Error **errp)
 {
     VirtMachineState *vms = VIRT_MACHINE(obj);
 
-    return virt_dtb_randomness_enabled(vms);
+    /*
+     * Report the value the user set, not the effective one.  A confidential
+     * VM defaults to no randomness (see virt_dtb_randomness_enabled()), but
+     * a getter that did not round-trip its setter would be surprising.
+     */
+    return vms->dtb_randomness;
 }
 
 static void virt_set_dtb_randomness(Object *obj, bool value, Error **errp)
@@ -3535,7 +3540,7 @@ static int virt_kvm_type(MachineState *ms, const char *type_str)
 
     vm_type = (ms->cgs ? KVM_VM_TYPE_ARM_REALM : KVM_VM_TYPE_ARM_NORMAL);
 
-    if (vm_type) {
+    if (ms->cgs) {
         /*
          * With RME, the upper GPA bit differentiates Realm from NS memory.
          * Reserve the upper bit to ensure that highmem devices will fit.

--- a/hw/core/loader.c
+++ b/hw/core/loader.c
@@ -74,6 +74,8 @@
 #endif
 
 static int roms_loaded;
+static NotifierList rom_loader_notifier =
+    NOTIFIER_LIST_INITIALIZER(rom_loader_notifier);
 
 /* return the size or -1 if error */
 int64_t get_image_size(const char *filename, Error **errp)
@@ -1201,6 +1203,11 @@ MemoryRegion *rom_add_blob(const char *name, const void *blob, size_t len,
     return mr;
 }
 
+void rom_add_load_notifier(Notifier *notifier)
+{
+    notifier_list_add(&rom_loader_notifier, notifier);
+}
+
 /* This function is specific for elf program because we don't need to allocate
  * all the rom. We just allocate the first part and the rest is just zeros. This
  * is why romsize and datasize are different. Also, this function takes its own
@@ -1242,6 +1249,7 @@ ssize_t rom_add_option(const char *file, int32_t bootindex)
 static void rom_reset(void *unused)
 {
     Rom *rom;
+    RomLoaderNotifyData notify;
 
     QTAILQ_FOREACH(rom, &roms, next) {
         if (rom->fw_file) {
@@ -1290,6 +1298,13 @@ static void rom_reset(void *unused)
         address_space_flush_icache_range(rom->as, rom->addr, rom->datasize);
 
         trace_loader_write_rom(rom->name, rom->addr, rom->datasize, rom->isrom);
+
+        notify = (RomLoaderNotifyData) {
+            .addr = rom->addr,
+            .len = rom->datasize,
+            .as = rom->as,
+        };
+        notifier_list_notify(&rom_loader_notifier, &notify);
     }
 }
 

--- a/hw/core/loader.c
+++ b/hw/core/loader.c
@@ -1301,7 +1301,8 @@ static void rom_reset(void *unused)
 
         notify = (RomLoaderNotifyData) {
             .addr = rom->addr,
-            .len = rom->datasize,
+            /* Include zero-filled tails such as ELF PT_LOAD BSS. */
+            .len = rom->romsize,
             .as = rom->as,
         };
         notifier_list_notify(&rom_loader_notifier, &notify);

--- a/hw/vfio/iommufd-stubs.c
+++ b/hw/vfio/iommufd-stubs.c
@@ -5,8 +5,10 @@
  */
 
 #include "qemu/osdep.h"
+#include "qapi/error.h"
 #include "migration/cpr.h"
 #include "migration/vmstate.h"
+#include "system/iommufd.h"
 
 const VMStateDescription vmstate_cpr_vfio_devices = {
     .name = CPR_STATE "/vfio devices",
@@ -16,3 +18,61 @@ const VMStateDescription vmstate_cpr_vfio_devices = {
         VMSTATE_END_OF_LIST()
     }
 };
+
+/*
+ * Arm RME device assignment.  target/arm/kvm.c dispatches the RHI
+ * device-assignment hypercalls unconditionally, but the implementations live
+ * in iommufd.c which is only built for CONFIG_VFIO && CONFIG_IOMMUFD.  Without
+ * IOMMUFD there can be no assigned device, so every lookup fails with -ENODEV
+ * and the guest sees RHI_DA_ERROR_INVALID_VDEV_ID.
+ */
+int iommufd_vdevice_register(VFIODevice *vbasedev, Error **errp)
+{
+    error_setg(errp, "IOMMUFD support is not compiled in");
+    return -ENOSYS;
+}
+
+int iommufd_tsm_bind(uint32_t rid)
+{
+    return -ENODEV;
+}
+
+int iommufd_tsm_unbind(uint32_t rid)
+{
+    return -ENODEV;
+}
+
+int iommufd_tsm_da_set_tdi_state_run(uint32_t rid)
+{
+    return -ENODEV;
+}
+
+int iommufd_tsm_get_da_object_size(uint32_t rid, uint32_t object_type,
+                                   uint32_t *object_size)
+{
+    return -ENODEV;
+}
+
+int iommufd_tsm_da_object_read(uint32_t rid, uint32_t object_type,
+                               uint64_t offset, void *buf, uint32_t max_len,
+                               uint32_t *resp_len)
+{
+    return -ENODEV;
+}
+
+int iommufd_tsm_da_get_interface_report(uint32_t rid)
+{
+    return -ENODEV;
+}
+
+int iommufd_tsm_da_get_measurement(uint32_t rid,
+                                   struct rhi_vdev_measurement_params *param)
+{
+    return -ENODEV;
+}
+
+bool iommufd_tsm_dev_memmap_exit(uint32_t rid, uint64_t gpa_base,
+                                 uint64_t gpa_top, uint64_t pa_base)
+{
+    return false;
+}

--- a/hw/vfio/iommufd.c
+++ b/hw/vfio/iommufd.c
@@ -44,48 +44,43 @@
 #define VFIO_STRTAB_STE_0_V          (1UL << 0)
 #define VFIO_STRTAB_STE_0_CFG_BYPASS 4
 
-int iommufd_tsm_bind(unsigned long vdev_id)
+static bool iommufd_tsm_vdevice_is_registered(VFIODevice *vbasedev)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    return vbasedev && vbasedev->iommufd_vdevice && vbasedev->vdevice_id;
+}
+
+static int iommufd_tsm_op(uint32_t rid, uint32_t op)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(rid);
     struct iommu_vdevice_tsm_op tsm_op;
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+    if (!iommufd_tsm_vdevice_is_registered(vbasedev)) {
         return -ENODEV;
     }
 
     tsm_op.size = sizeof(struct iommu_vdevice_tsm_op);
     tsm_op.flags = 0;
-    tsm_op.op = IOMMU_VDEVICE_TSM_BIND;
+    tsm_op.op = op;
     tsm_op.vdevice_id = vbasedev->vdevice_id;
 
     if (ioctl(vbasedev->iommufd->fd, IOMMU_VDEVICE_TSM_OP, &tsm_op)) {
-        warn_report("Failed to TSM bind vdevice: %d", errno);
-        return -errno;
+        int ret = -errno;
+
+        trace_iommufd_tsm_op_failed(rid, op, errno);
+        return ret;
     }
 
     return 0;
 }
 
-int iommufd_tsm_unbind(unsigned long vdev_id)
+int iommufd_tsm_bind(uint32_t rid)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
-    struct iommu_vdevice_tsm_op tsm_op;
+    return iommufd_tsm_op(rid, IOMMU_VDEVICE_TSM_BIND);
+}
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
-        return -ENODEV;
-    }
-
-    tsm_op.size = sizeof(struct iommu_vdevice_tsm_op);
-    tsm_op.flags = 0;
-    tsm_op.op = IOMMU_VDEVICE_TSM_UNBIND;
-    tsm_op.vdevice_id = vbasedev->vdevice_id;
-
-    if (ioctl(vbasedev->iommufd->fd, IOMMU_VDEVICE_TSM_OP, &tsm_op)) {
-        warn_report("Failed to TSM unbind vdevice: %d", errno);
-        return -errno;
-    }
-
-    return 0;
+int iommufd_tsm_unbind(uint32_t rid)
+{
+    return iommufd_tsm_op(rid, IOMMU_VDEVICE_TSM_UNBIND);
 }
 
 static int iommufd_tsm_guest_request(VFIODevice *vbasedev,
@@ -108,11 +103,27 @@ static int iommufd_tsm_guest_request(VFIODevice *vbasedev,
     ret = ioctl(vbasedev->iommufd->fd, IOMMU_VDEVICE_TSM_GUEST_REQUEST,
                 &guest_req);
     if (ret < 0) {
-        warn_report("IOMMU_VDEVICE_TSM_GUEST_REQUEST failed: %d", errno);
-        return -errno;
+        int err = -errno;
+
+        /*
+         * These requests are issued on behalf of the guest, so a failure is
+         * not necessarily a host problem and must not be reportable at will
+         * by the guest.  Trace rather than warn_report().
+         */
+        trace_iommufd_tsm_guest_request_failed(vdevice_id, scope, errno);
+        return err;
     }
 
-    /* return value is the residue */
+    /*
+     * The return value is response residue when a response buffer is present,
+     * or unconsumed request bytes for a request-only operation.  Every caller
+     * requires the complete request to be consumed, and a response residue
+     * cannot exceed the supplied response buffer.
+     */
+    if ((uint32_t)ret > resp_len) {
+        trace_iommufd_tsm_guest_request_bad_residue(vdevice_id, ret, resp_len);
+        return -EIO;
+    }
     if (actual_resp_len) {
         *actual_resp_len = resp_len - ret;
     }
@@ -120,15 +131,15 @@ static int iommufd_tsm_guest_request(VFIODevice *vbasedev,
     return 0;
 }
 
-int iommufd_tsm_da_set_tdi_state_run(unsigned int vdev_id)
+int iommufd_tsm_da_set_tdi_state_run(uint32_t rid)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    VFIODevice *vbasedev = vfio_find_bdf(rid);
     struct arm64_vdev_set_tdi_state_guest_req req = {
         .req_type = __RHI_DA_VDEV_SET_TDI_STATE,
         .tdi_state = RHI_DA_TDI_CONFIG_RUN,
     };
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+    if (!iommufd_tsm_vdevice_is_registered(vbasedev)) {
         return -ENODEV;
     }
 
@@ -138,11 +149,10 @@ int iommufd_tsm_da_set_tdi_state_run(unsigned int vdev_id)
                                      NULL, 0, NULL);
 }
 
-int iommufd_tsm_get_da_object_size(unsigned int vdev_id,
-       unsigned int object_type,
-       unsigned int *object_size)
+int iommufd_tsm_get_da_object_size(uint32_t rid, uint32_t object_type,
+                                   uint32_t *object_size)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    VFIODevice *vbasedev = vfio_find_bdf(rid);
     struct arm64_vdev_object_size_guest_req req = {
         .req_type = __RHI_DA_OBJECT_SIZE,
         .object_type = object_type,
@@ -150,7 +160,7 @@ int iommufd_tsm_get_da_object_size(unsigned int vdev_id,
     uint32_t resp_len = 0;
     int ret;
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+    if (!iommufd_tsm_vdevice_is_registered(vbasedev)) {
         return -ENODEV;
     }
 
@@ -162,27 +172,24 @@ int iommufd_tsm_get_da_object_size(unsigned int vdev_id,
     if (ret) {
         return ret;
     }
-    if (resp_len != sizeof(int)) {
+    if (resp_len != sizeof(*object_size)) {
         return -EINVAL;
     }
     return 0;
 }
 
-int iommufd_tsm_da_object_read(unsigned int vdev_id,
-       unsigned int object_type,
-       unsigned long offset,
-       void *buf,
-       unsigned long max_len,
-       unsigned int *resp_len)
+int iommufd_tsm_da_object_read(uint32_t rid, uint32_t object_type,
+                               uint64_t offset, void *buf, uint32_t max_len,
+                               uint32_t *resp_len)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    VFIODevice *vbasedev = vfio_find_bdf(rid);
     struct arm64_vdev_object_read_guest_req req = {
         .req_type = __RHI_DA_OBJECT_READ,
         .object_type = object_type,
         .offset = offset,
     };
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+    if (!iommufd_tsm_vdevice_is_registered(vbasedev)) {
         return -ENODEV;
     }
 
@@ -192,12 +199,12 @@ int iommufd_tsm_da_object_read(unsigned int vdev_id,
                                      buf, max_len, resp_len);
 }
 
-int iommufd_tsm_da_get_interface_report(unsigned int vdev_id)
+int iommufd_tsm_da_get_interface_report(uint32_t rid)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
-    __u32 req_type;
+    VFIODevice *vbasedev = vfio_find_bdf(rid);
+    uint32_t req_type;
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+    if (!iommufd_tsm_vdevice_is_registered(vbasedev)) {
         return -ENODEV;
     }
 
@@ -208,17 +215,17 @@ int iommufd_tsm_da_get_interface_report(unsigned int vdev_id)
                                      NULL, 0, NULL);
 }
 
-int iommufd_tsm_da_get_measurement(unsigned int vdev_id,
-       struct rhi_vdev_measurement_params *param)
+int iommufd_tsm_da_get_measurement(uint32_t rid,
+                                   struct rhi_vdev_measurement_params *param)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    VFIODevice *vbasedev = vfio_find_bdf(rid);
     struct arm64_vdev_device_measurement_guest_req req = {
         .req_type = __RHI_DA_VDEV_UPDATE_MEASUREMENTS,
         .flags = param->flags,
         .nonce = (uintptr_t)&param->nonce[0],
     };
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+    if (!iommufd_tsm_vdevice_is_registered(vbasedev)) {
         return -ENODEV;
     }
 
@@ -228,23 +235,26 @@ int iommufd_tsm_da_get_measurement(unsigned int vdev_id,
                                      NULL, 0, NULL);
 }
 
-bool iommufd_tsm_dev_memmap_exit(unsigned long vdev_id,
-    unsigned long gpa_base, unsigned long gpa_top,
-    unsigned long pa_base)
+bool iommufd_tsm_dev_memmap_exit(uint32_t rid, uint64_t gpa_base,
+                                 uint64_t gpa_top, uint64_t pa_base)
 {
-    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    VFIODevice *vbasedev = vfio_find_bdf(rid);
     struct arm64_vdev_device_memmap_guest_req req = {
         .req_type = __REC_DA_VDEV_MAP,
         .gpa_base = gpa_base,
         .gpa_top = gpa_top,
         .pa_base = pa_base,
     };
-    uint64_t range_size = gpa_top - gpa_base;
+    uint64_t range_size;
     bool ok;
 
-    if (!vbasedev || !vbasedev->iommufd_vdevice) {
-            return false;
+    if (!iommufd_tsm_vdevice_is_registered(vbasedev)) {
+        return false;
     }
+    if (gpa_top <= gpa_base) {
+        return false;
+    }
+    range_size = gpa_top - gpa_base;
 
     /*
      * Mark the IPA window PRIVATE before the iommufd guest-request reaches
@@ -278,6 +288,7 @@ bool iommufd_tsm_dev_memmap_exit(unsigned long vdev_id,
         kvm_set_memory_attributes_shared(gpa_base, range_size);
     }
 
+    trace_iommufd_tsm_dev_memmap(rid, gpa_base, gpa_top, pa_base, ok);
     return ok;
 }
 
@@ -578,7 +589,11 @@ static int iommufd_cdev_attach_ioas_hwpt(VFIODevice *vbasedev, uint32_t id,
 int iommufd_vdevice_register(VFIODevice *vbasedev, Error **errp)
 {
     IOMMUFDBackend *iommufd = vbasedev->iommufd;
-    struct iommu_vdevice_alloc alloc_vdev;
+    struct iommu_vdevice_alloc alloc_vdev = {
+        .size = sizeof(alloc_vdev),
+        .viommu_id = vbasedev->hwpt->viommu_id,
+        .dev_id = vbasedev->devid,
+    };
     VFIOPCIDevice *vdev;
     int ret;
 
@@ -589,9 +604,6 @@ int iommufd_vdevice_register(VFIODevice *vbasedev, Error **errp)
 
     vdev = container_of(vbasedev, VFIOPCIDevice, vbasedev);
 
-    alloc_vdev.size = sizeof(alloc_vdev);
-    alloc_vdev.viommu_id = vbasedev->hwpt->viommu_id;
-    alloc_vdev.dev_id = vbasedev->devid;
     /* Guest-visible RID: segment (0) in bits [31:16], BDF in bits [15:0]. */
     alloc_vdev.virt_id = pci_get_bdf(&vdev->parent_obj);
 
@@ -655,7 +667,10 @@ iommufd_cdev_alloc_viommu_hwpt(VFIODevice *vbasedev,
         .dev_id = vbasedev->devid,
     };
     VFIOIOASHwpt *hwpt;
+    Error *detach_err = NULL;
     uint32_t hwpt_id;
+    bool parent_attached = false;
+    bool viommu_allocated = false;
     int ret;
 
     if (!iommufd_backend_alloc_hwpt(iommufd, vbasedev->devid,
@@ -675,12 +690,14 @@ iommufd_cdev_alloc_viommu_hwpt(VFIODevice *vbasedev,
     if (ret) {
         goto err_free;
     }
+    parent_attached = true;
 
     alloc_viommu.hwpt_id = hwpt->hwpt_id;
     if (ioctl(iommufd->fd, IOMMU_VIOMMU_ALLOC, &alloc_viommu)) {
         error_setg_errno(errp, errno, "failed to allocate VIOMMU");
         goto err_free;
     }
+    viommu_allocated = true;
 
     if (!iommufd_backend_alloc_hwpt(iommufd, vbasedev->devid,
                                     alloc_viommu.out_viommu_id, 0,
@@ -696,6 +713,15 @@ iommufd_cdev_alloc_viommu_hwpt(VFIODevice *vbasedev,
     return hwpt;
 
 err_free:
+    if (viommu_allocated) {
+        iommufd_backend_free_id(container->be,
+                                alloc_viommu.out_viommu_id);
+    }
+    if (parent_attached &&
+        !iommufd_cdev_detach_ioas_hwpt(vbasedev, &detach_err)) {
+        error_reportf_err(detach_err,
+                          "failed to detach device while unwinding: ");
+    }
     iommufd_backend_free_id(container->be, hwpt->hwpt_id);
     g_free(hwpt);
     return NULL;
@@ -718,6 +744,13 @@ static bool iommufd_cdev_autodomains_get(VFIODevice *vbasedev,
 
     /* Try to find a domain */
     QLIST_FOREACH(hwpt, &container->hwpt_list, next) {
+        bool hwpt_has_vdevice = hwpt->viommu_id && hwpt->nested_hwpt_id;
+
+        /* Never mix regular devices and Realm vDevices in one HWPT. */
+        if (vbasedev->iommufd_vdevice != hwpt_has_vdevice) {
+            continue;
+        }
+
         if (!cpr_is_incoming()) {
             ret = iommufd_cdev_attach_ioas_hwpt(vbasedev, hwpt->hwpt_id, errp);
         } else if (vbasedev->cpr.hwpt_id == hwpt->hwpt_id) {
@@ -764,8 +797,8 @@ static bool iommufd_cdev_autodomains_get(VFIODevice *vbasedev,
          */
         if (!iommufd_backend_get_device_info(vbasedev->iommufd,
                                              vbasedev->devid, &type, &caps,
-                                             sizeof(caps), &hw_caps, NULL,
-                                             errp)) {
+                                             sizeof(caps), &hw_caps,
+                                             NULL, errp)) {
             return false;
         }
 

--- a/hw/vfio/iommufd.c
+++ b/hw/vfio/iommufd.c
@@ -21,6 +21,7 @@
 #include "qapi/error.h"
 #include "system/iommufd.h"
 #include "hw/core/qdev.h"
+#include "system/kvm.h"
 #include "hw/vfio/vfio-cpr.h"
 #include "system/reset.h"
 #include "qemu/cutils.h"
@@ -30,9 +31,255 @@
 #include "vfio-iommufd.h"
 #include "vfio-helpers.h"
 #include "vfio-listener.h"
+#include "linux-headers/linux/arm-smccc.h"
+#include "linux-headers/linux/tsm.h"
 
 #define TYPE_HOST_IOMMU_DEVICE_IOMMUFD_VFIO             \
             TYPE_HOST_IOMMU_DEVICE_IOMMUFD "-vfio"
+
+/*
+ * Arm SMMUv3 stream-table-entry bits used to build a stage-1 bypass STE for
+ * the nested (VIOMMU) domain in the RME device-assignment flow.
+ */
+#define VFIO_STRTAB_STE_0_V          (1UL << 0)
+#define VFIO_STRTAB_STE_0_CFG_BYPASS 4
+
+int iommufd_tsm_bind(unsigned long vdev_id)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    struct iommu_vdevice_tsm_op tsm_op;
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+        return -ENODEV;
+    }
+
+    tsm_op.size = sizeof(struct iommu_vdevice_tsm_op);
+    tsm_op.flags = 0;
+    tsm_op.op = IOMMU_VDEVICE_TSM_BIND;
+    tsm_op.vdevice_id = vbasedev->vdevice_id;
+
+    if (ioctl(vbasedev->iommufd->fd, IOMMU_VDEVICE_TSM_OP, &tsm_op)) {
+        warn_report("Failed to TSM bind vdevice: %d", errno);
+        return -errno;
+    }
+
+    return 0;
+}
+
+int iommufd_tsm_unbind(unsigned long vdev_id)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    struct iommu_vdevice_tsm_op tsm_op;
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+        return -ENODEV;
+    }
+
+    tsm_op.size = sizeof(struct iommu_vdevice_tsm_op);
+    tsm_op.flags = 0;
+    tsm_op.op = IOMMU_VDEVICE_TSM_UNBIND;
+    tsm_op.vdevice_id = vbasedev->vdevice_id;
+
+    if (ioctl(vbasedev->iommufd->fd, IOMMU_VDEVICE_TSM_OP, &tsm_op)) {
+        warn_report("Failed to TSM unbind vdevice: %d", errno);
+        return -errno;
+    }
+
+    return 0;
+}
+
+static int iommufd_tsm_guest_request(VFIODevice *vbasedev,
+                                     uint32_t vdevice_id, uint32_t scope,
+                                     void *req, uint32_t req_len,
+                                     void *resp, uint32_t resp_len,
+                                     uint32_t *actual_resp_len)
+{
+    struct iommu_vdevice_tsm_guest_request guest_req = {
+        .size = sizeof(guest_req),
+        .vdevice_id = vdevice_id,
+        .scope = scope,
+        .req_uptr = (uintptr_t)req,
+        .req_len = req_len,
+        .resp_uptr = (uintptr_t)resp,
+        .resp_len = resp_len,
+    };
+    int ret;
+
+    ret = ioctl(vbasedev->iommufd->fd, IOMMU_VDEVICE_TSM_GUEST_REQUEST,
+                &guest_req);
+    if (ret < 0) {
+        warn_report("IOMMU_VDEVICE_TSM_GUEST_REQUEST failed: %d", errno);
+        return -errno;
+    }
+
+    /* return value is the residue */
+    if (actual_resp_len) {
+        *actual_resp_len = resp_len - ret;
+    }
+
+    return 0;
+}
+
+int iommufd_tsm_da_set_tdi_state_run(unsigned int vdev_id)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    struct arm64_vdev_set_tdi_state_guest_req req = {
+        .req_type = __RHI_DA_VDEV_SET_TDI_STATE,
+        .tdi_state = RHI_DA_TDI_CONFIG_RUN,
+    };
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+        return -ENODEV;
+    }
+
+    return iommufd_tsm_guest_request(vbasedev, vbasedev->vdevice_id,
+                                     PCI_TSM_REQ_STATE_CHANGE,
+                                     &req, sizeof(req),
+                                     NULL, 0, NULL);
+}
+
+int iommufd_tsm_get_da_object_size(unsigned int vdev_id,
+       unsigned int object_type,
+       unsigned int *object_size)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    struct arm64_vdev_object_size_guest_req req = {
+        .req_type = __RHI_DA_OBJECT_SIZE,
+        .object_type = object_type,
+    };
+    uint32_t resp_len = 0;
+    int ret;
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+        return -ENODEV;
+    }
+
+    ret = iommufd_tsm_guest_request(vbasedev, vbasedev->vdevice_id,
+                                    PCI_TSM_REQ_INFO,
+                                    &req, sizeof(req),
+                                    object_size, sizeof(*object_size),
+                                    &resp_len);
+    if (ret) {
+        return ret;
+    }
+    if (resp_len != sizeof(int)) {
+        return -EINVAL;
+    }
+    return 0;
+}
+
+int iommufd_tsm_da_object_read(unsigned int vdev_id,
+       unsigned int object_type,
+       unsigned long offset,
+       void *buf,
+       unsigned long max_len,
+       unsigned int *resp_len)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    struct arm64_vdev_object_read_guest_req req = {
+        .req_type = __RHI_DA_OBJECT_READ,
+        .object_type = object_type,
+        .offset = offset,
+    };
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+        return -ENODEV;
+    }
+
+    return iommufd_tsm_guest_request(vbasedev, vbasedev->vdevice_id,
+                                     PCI_TSM_REQ_INFO,
+                                     &req, sizeof(req),
+                                     buf, max_len, resp_len);
+}
+
+int iommufd_tsm_da_get_interface_report(unsigned int vdev_id)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    __u32 req_type;
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+        return -ENODEV;
+    }
+
+    req_type = __RHI_DA_VDEV_UPDATE_INTERFACE_REPORT;
+    return iommufd_tsm_guest_request(vbasedev, vbasedev->vdevice_id,
+                                     PCI_TSM_REQ_INFO,
+                                     &req_type, sizeof(req_type),
+                                     NULL, 0, NULL);
+}
+
+int iommufd_tsm_da_get_measurement(unsigned int vdev_id,
+       struct rhi_vdev_measurement_params *param)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    struct arm64_vdev_device_measurement_guest_req req = {
+        .req_type = __RHI_DA_VDEV_UPDATE_MEASUREMENTS,
+        .flags = param->flags,
+        .nonce = (uintptr_t)&param->nonce[0],
+    };
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+        return -ENODEV;
+    }
+
+    return iommufd_tsm_guest_request(vbasedev, vbasedev->vdevice_id,
+                                     PCI_TSM_REQ_INFO,
+                                     &req, sizeof(req),
+                                     NULL, 0, NULL);
+}
+
+bool iommufd_tsm_dev_memmap_exit(unsigned long vdev_id,
+    unsigned long gpa_base, unsigned long gpa_top,
+    unsigned long pa_base)
+{
+    VFIODevice *vbasedev = vfio_find_bdf(vdev_id);
+    struct arm64_vdev_device_memmap_guest_req req = {
+        .req_type = __REC_DA_VDEV_MAP,
+        .gpa_base = gpa_base,
+        .gpa_top = gpa_top,
+        .pa_base = pa_base,
+    };
+    uint64_t range_size = gpa_top - gpa_base;
+    bool ok;
+
+    if (!vbasedev || !vbasedev->iommufd_vdevice) {
+            return false;
+    }
+
+    /*
+     * Mark the IPA window PRIVATE before the iommufd guest-request reaches
+     * the host TSM/iommufd and the kernel installs ASSIGNED-DEV S2 entries
+     * via realm_dev_mem_map(). This is the VDEV-side equivalent of the
+     * RIPAS-change handshake used for RAM (rec_exit_ripas_change ->
+     * KVM_EXIT_MEMORY_FAULT -> kvm_convert_memory) and gives the kernel's
+     * realm_clamp_order() the neighbour signal it needs to refuse a 2 MiB
+     * unprotected coalescing over VDEV-locked PAs.
+     *
+     * Set the attribute *before* the iommufd call: the
+     * kvm_arch_post_set_memory_attributes() callback sweeps away any stale
+     * NS S2 entries on those gfns (KVM_FILTER_SHARED) before the DEV
+     * mapping lands, closing the race against other vCPUs faulting on the
+     * unprotected alias in the window between VDEV_MAP exit and the host
+     * actually installing the DEV S2.
+     */
+    if (kvm_set_memory_attributes_private(gpa_base, range_size)) {
+        return false;
+    }
+
+    ok = iommufd_tsm_guest_request(vbasedev, vbasedev->vdevice_id,
+                                   PCI_TSM_REQ_STATE_CHANGE,
+                                   &req, sizeof(req),
+                                   NULL, 0, NULL) == 0;
+    if (!ok) {
+        /*
+         * Roll back the attribute change so the realm doesn't get stuck
+         * with PRIVATE-locked gfns that have no backing DEV mapping.
+         */
+        kvm_set_memory_attributes_shared(gpa_base, range_size);
+    }
+
+    return ok;
+}
 
 static int iommufd_cdev_map(const VFIOContainer *bcontainer, hwaddr iova,
                             uint64_t size, void *vaddr, bool readonly,
@@ -328,6 +575,44 @@ static int iommufd_cdev_attach_ioas_hwpt(VFIODevice *vbasedev, uint32_t id,
     return 0;
 }
 
+int iommufd_vdevice_register(VFIODevice *vbasedev, Error **errp)
+{
+    IOMMUFDBackend *iommufd = vbasedev->iommufd;
+    struct iommu_vdevice_alloc alloc_vdev;
+    VFIOPCIDevice *vdev;
+    int ret;
+
+    if (vbasedev->type != VFIO_DEVICE_TYPE_PCI) {
+        error_setg(errp, "vdevice registration is only supported for PCI");
+        return -EINVAL;
+    }
+
+    vdev = container_of(vbasedev, VFIOPCIDevice, vbasedev);
+
+    alloc_vdev.size = sizeof(alloc_vdev);
+    alloc_vdev.viommu_id = vbasedev->hwpt->viommu_id;
+    alloc_vdev.dev_id = vbasedev->devid;
+    /* Guest-visible RID: segment (0) in bits [31:16], BDF in bits [15:0]. */
+    alloc_vdev.virt_id = pci_get_bdf(&vdev->parent_obj);
+
+    if (ioctl(iommufd->fd, IOMMU_VDEVICE_ALLOC, &alloc_vdev)) {
+        ret = -errno;
+        error_setg_errno(errp, errno, "failed to allocate vdevice");
+        return ret;
+    }
+
+    ret = iommufd_cdev_attach_ioas_hwpt(vbasedev,
+                                        vbasedev->hwpt->nested_hwpt_id, errp);
+    if (ret) {
+        iommufd_backend_free_id(iommufd, alloc_vdev.out_vdevice_id);
+        return ret;
+    }
+
+    vbasedev->vdevice_id = alloc_vdev.out_vdevice_id;
+
+    return 0;
+}
+
 static bool iommufd_cdev_detach_ioas_hwpt(VFIODevice *vbasedev, Error **errp)
 {
     int iommufd = vbasedev->iommufd->fd;
@@ -343,6 +628,77 @@ static bool iommufd_cdev_detach_ioas_hwpt(VFIODevice *vbasedev, Error **errp)
 
     trace_iommufd_cdev_detach_ioas_hwpt(iommufd, vbasedev->name);
     return true;
+}
+
+/*
+ * Allocate the nested-translation topology used for RME device assignment: a
+ * stage-2 nesting-parent HWPT, a VIOMMU on top of it, and a stage-1 bypass
+ * HWPT nested under the VIOMMU. Returns the parent VFIOIOASHwpt (with
+ * nested_hwpt_id populated) on success, or NULL with @errp set on failure.
+ */
+static VFIOIOASHwpt *
+iommufd_cdev_alloc_viommu_hwpt(VFIODevice *vbasedev,
+                               VFIOIOMMUFDContainer *container,
+                               Error **errp)
+{
+    IOMMUFDBackend *iommufd = vbasedev->iommufd;
+    struct iommu_hwpt_arm_smmuv3 bypass_ste = {
+        .ste = {
+            VFIO_STRTAB_STE_0_V | (VFIO_STRTAB_STE_0_CFG_BYPASS << 1),
+            0,
+        },
+    };
+    struct iommu_viommu_alloc alloc_viommu = {
+        .size = sizeof(alloc_viommu),
+        .flags = 0,
+        .type = IOMMU_VIOMMU_TYPE_ARM_REALM_SMMUV3,
+        .dev_id = vbasedev->devid,
+    };
+    VFIOIOASHwpt *hwpt;
+    uint32_t hwpt_id;
+    int ret;
+
+    if (!iommufd_backend_alloc_hwpt(iommufd, vbasedev->devid,
+                                    container->ioas_id,
+                                    IOMMU_HWPT_ALLOC_NEST_PARENT,
+                                    IOMMU_HWPT_DATA_NONE, 0, NULL,
+                                    &hwpt_id, errp)) {
+        return NULL;
+    }
+
+    hwpt = g_malloc0(sizeof(*hwpt));
+    hwpt->hwpt_id = hwpt_id;
+    hwpt->hwpt_flags = IOMMU_HWPT_ALLOC_NEST_PARENT;
+    QLIST_INIT(&hwpt->device_list);
+
+    ret = iommufd_cdev_attach_ioas_hwpt(vbasedev, hwpt->hwpt_id, errp);
+    if (ret) {
+        goto err_free;
+    }
+
+    alloc_viommu.hwpt_id = hwpt->hwpt_id;
+    if (ioctl(iommufd->fd, IOMMU_VIOMMU_ALLOC, &alloc_viommu)) {
+        error_setg_errno(errp, errno, "failed to allocate VIOMMU");
+        goto err_free;
+    }
+
+    if (!iommufd_backend_alloc_hwpt(iommufd, vbasedev->devid,
+                                    alloc_viommu.out_viommu_id, 0,
+                                    IOMMU_HWPT_DATA_ARM_SMMUV3,
+                                    sizeof(bypass_ste), &bypass_ste,
+                                    &hwpt_id, errp)) {
+        goto err_free;
+    }
+
+    hwpt->viommu_id = alloc_viommu.out_viommu_id;
+    hwpt->nested_hwpt_id = hwpt_id;
+
+    return hwpt;
+
+err_free:
+    iommufd_backend_free_id(container->be, hwpt->hwpt_id);
+    g_free(hwpt);
+    return NULL;
 }
 
 static bool iommufd_cdev_autodomains_get(VFIODevice *vbasedev,
@@ -393,67 +749,75 @@ static bool iommufd_cdev_autodomains_get(VFIODevice *vbasedev,
         }
     }
 
-    /*
-     * This is quite early and VFIO Migration state isn't yet fully
-     * initialized, thus rely only on IOMMU hardware capabilities as to
-     * whether IOMMU dirty tracking is going to be requested. Later
-     * vfio_migration_realize() may decide to use VF dirty tracking
-     * instead.
-     */
-    if (!iommufd_backend_get_device_info(vbasedev->iommufd, vbasedev->devid,
-                                         &type, &caps, sizeof(caps), &hw_caps,
-                                         NULL, errp)) {
-        return false;
-    }
-
-    viommu_nesting = vfio_device_get_viommu_flags_want_nesting(vbasedev);
-    viommu_nesting_dirty =
-        vfio_device_get_viommu_flags_want_nesting_dirty(vbasedev);
-
-    if (hw_caps & IOMMU_HW_CAP_DIRTY_TRACKING) {
-        if (!viommu_nesting || viommu_nesting_dirty) {
-            flags |= IOMMU_HWPT_ALLOC_DIRTY_TRACKING;
+    if (vbasedev->iommufd_vdevice) {
+        hwpt = iommufd_cdev_alloc_viommu_hwpt(vbasedev, container, errp);
+        if (!hwpt) {
+            return false;
         }
-    }
-
-    /*
-     * If vIOMMU requests VFIO's cooperation to create nesting parent HWPT,
-     * force to create it so that it could be reused by vIOMMU to create
-     * nested HWPT.
-     */
-    if (viommu_nesting) {
-        flags |= IOMMU_HWPT_ALLOC_NEST_PARENT;
-
-        if (vfio_device_get_host_iommu_quirk_bypass_ro(vbasedev, type,
-                                                       &caps, sizeof(caps))) {
-            bcontainer->bypass_ro = true;
+    } else {
+        /*
+         * This is quite early and VFIO Migration state isn't yet fully
+         * initialized, thus rely only on IOMMU hardware capabilities as to
+         * whether IOMMU dirty tracking is going to be requested. Later
+         * vfio_migration_realize() may decide to use VF dirty tracking
+         * instead.
+         */
+        if (!iommufd_backend_get_device_info(vbasedev->iommufd,
+                                             vbasedev->devid, &type, &caps,
+                                             sizeof(caps), &hw_caps, NULL,
+                                             errp)) {
+            return false;
         }
-    }
 
-    if (cpr_is_incoming()) {
-        hwpt_id = vbasedev->cpr.hwpt_id;
-        goto skip_alloc;
-    }
+        viommu_nesting = vfio_device_get_viommu_flags_want_nesting(vbasedev);
+        viommu_nesting_dirty =
+            vfio_device_get_viommu_flags_want_nesting_dirty(vbasedev);
 
-    if (!iommufd_backend_alloc_hwpt(iommufd, vbasedev->devid,
-                                    container->ioas_id, flags,
-                                    IOMMU_HWPT_DATA_NONE, 0, NULL,
-                                    &hwpt_id, errp)) {
-        return false;
-    }
+        if (hw_caps & IOMMU_HW_CAP_DIRTY_TRACKING) {
+            if (!viommu_nesting || viommu_nesting_dirty) {
+                flags |= IOMMU_HWPT_ALLOC_DIRTY_TRACKING;
+            }
+        }
 
-    ret = iommufd_cdev_attach_ioas_hwpt(vbasedev, hwpt_id, errp);
-    if (ret) {
-        iommufd_backend_free_id(container->be, hwpt_id);
-        return false;
-    }
+        /*
+         * If vIOMMU requests VFIO's cooperation to create nesting parent HWPT,
+         * force to create it so that it could be reused by vIOMMU to create
+         * nested HWPT.
+         */
+        if (viommu_nesting) {
+            flags |= IOMMU_HWPT_ALLOC_NEST_PARENT;
+
+            if (vfio_device_get_host_iommu_quirk_bypass_ro(vbasedev, type,
+                                                           &caps,
+                                                           sizeof(caps))) {
+                bcontainer->bypass_ro = true;
+            }
+        }
+
+        if (cpr_is_incoming()) {
+            hwpt_id = vbasedev->cpr.hwpt_id;
+            goto skip_alloc;
+        }
+
+        if (!iommufd_backend_alloc_hwpt(iommufd, vbasedev->devid,
+                                        container->ioas_id, flags,
+                                        IOMMU_HWPT_DATA_NONE, 0, NULL,
+                                        &hwpt_id, errp)) {
+            return false;
+        }
+
+        ret = iommufd_cdev_attach_ioas_hwpt(vbasedev, hwpt_id, errp);
+        if (ret) {
+            iommufd_backend_free_id(container->be, hwpt_id);
+            return false;
+        }
 
 skip_alloc:
-    hwpt = g_malloc0(sizeof(*hwpt));
-    hwpt->hwpt_id = hwpt_id;
-    hwpt->hwpt_flags = flags;
-    QLIST_INIT(&hwpt->device_list);
-
+        hwpt = g_malloc0(sizeof(*hwpt));
+        hwpt->hwpt_id = hwpt_id;
+        hwpt->hwpt_flags = flags;
+        QLIST_INIT(&hwpt->device_list);
+    }
     vbasedev->hwpt = hwpt;
     vbasedev->cpr.hwpt_id = hwpt->hwpt_id;
     vbasedev->iommu_dirty_tracking = iommufd_hwpt_dirty_tracking(hwpt);
@@ -479,6 +843,17 @@ static void iommufd_cdev_autodomains_put(VFIODevice *vbasedev,
 
     if (QLIST_EMPTY(&hwpt->device_list)) {
         QLIST_REMOVE(hwpt, next);
+        /*
+         * Tear down the RME device-assignment nested topology (if any) in the
+         * reverse order it was allocated: stage-1 bypass HWPT, then the VIOMMU,
+         * then the stage-2 nesting-parent HWPT below.
+         */
+        if (hwpt->nested_hwpt_id) {
+            iommufd_backend_free_id(container->be, hwpt->nested_hwpt_id);
+        }
+        if (hwpt->viommu_id) {
+            iommufd_backend_free_id(container->be, hwpt->viommu_id);
+        }
         iommufd_backend_free_id(container->be, hwpt->hwpt_id);
         g_free(hwpt);
     }
@@ -507,10 +882,18 @@ static void iommufd_cdev_detach_container(VFIODevice *vbasedev,
         error_report_err(err);
     }
 
+    /*
+     * Destroy the VDEVICE before the VIOMMU it belongs to (freed in
+     * iommufd_cdev_autodomains_put() below), as required by the iommufd UAPI.
+     */
+    if (vbasedev->iommufd_vdevice && vbasedev->vdevice_id) {
+        iommufd_backend_free_id(container->be, vbasedev->vdevice_id);
+        vbasedev->vdevice_id = 0;
+    }
+
     if (vbasedev->hwpt) {
         iommufd_cdev_autodomains_put(vbasedev, container);
     }
-
 }
 
 static void iommufd_cdev_container_destroy(VFIOIOMMUFDContainer *container)

--- a/hw/vfio/listener.c
+++ b/hw/vfio/listener.c
@@ -76,6 +76,24 @@ static bool vfio_log_sync_needed(const VFIOContainer *bcontainer)
     return true;
 }
 
+VFIODevice *vfio_find_bdf(uint64_t sbdf)
+{
+    VFIOPCIDevice *pcidev;
+    VFIODevice *vbasedev;
+
+    QLIST_FOREACH(vbasedev, &vfio_device_list, global_next) {
+        if (vbasedev->type != VFIO_DEVICE_TYPE_PCI) {
+            continue;
+        }
+        pcidev = container_of(vbasedev, VFIOPCIDevice, vbasedev);
+        if (((uint64_t)pci_get_bdf(&pcidev->parent_obj)) == sbdf) {
+            return vbasedev;
+        }
+    }
+
+    return NULL;
+}
+
 static bool vfio_listener_skipped_section(MemoryRegionSection *section,
                                           bool bypass_ro)
 {

--- a/hw/vfio/listener.c
+++ b/hw/vfio/listener.c
@@ -76,7 +76,12 @@ static bool vfio_log_sync_needed(const VFIOContainer *bcontainer)
     return true;
 }
 
-VFIODevice *vfio_find_bdf(uint64_t sbdf)
+/*
+ * Look up an assigned PCI device by its guest-visible Routing ID: PCI segment
+ * in bits [31:16], BDF in bits [15:0].  Only segment 0 is modelled today, so
+ * anything above bit 15 never matches.
+ */
+VFIODevice *vfio_find_bdf(uint32_t rid)
 {
     VFIOPCIDevice *pcidev;
     VFIODevice *vbasedev;
@@ -86,7 +91,7 @@ VFIODevice *vfio_find_bdf(uint64_t sbdf)
             continue;
         }
         pcidev = container_of(vbasedev, VFIOPCIDevice, vbasedev);
-        if (((uint64_t)pci_get_bdf(&pcidev->parent_obj)) == sbdf) {
+        if ((uint32_t)pci_get_bdf(&pcidev->parent_obj) == rid) {
             return vbasedev;
         }
     }

--- a/hw/vfio/listener.c
+++ b/hw/vfio/listener.c
@@ -86,6 +86,9 @@ VFIODevice *vfio_find_bdf(uint32_t rid)
     VFIOPCIDevice *pcidev;
     VFIODevice *vbasedev;
 
+    /* vfio_device_list insertion and removal are protected by the BQL. */
+    assert(bql_locked());
+
     QLIST_FOREACH(vbasedev, &vfio_device_list, global_next) {
         if (vbasedev->type != VFIO_DEVICE_TYPE_PCI) {
             continue;

--- a/hw/vfio/pci.c
+++ b/hw/vfio/pci.c
@@ -58,7 +58,9 @@ static KVMRouteChange vfio_route_change;
 static void vfio_disable_interrupts(VFIOPCIDevice *vdev);
 static void vfio_mmap_set_enabled(VFIOPCIDevice *vdev, bool enabled);
 static void vfio_msi_disable_common(VFIOPCIDevice *vdev);
+#ifdef CONFIG_IOMMUFD
 static void vfio_register_bdf(PCIDevice *pci_dev);
+#endif
 
 /* Create new or reuse existing eventfd */
 static bool vfio_notifier_init(VFIOPCIDevice *vdev, EventNotifier *e,
@@ -1400,8 +1402,10 @@ uint32_t vfio_pci_read_config(PCIDevice *pdev, uint32_t addr, int len)
     VFIODevice *vbasedev = &vdev->vbasedev;
     uint32_t emu_bits = 0, emu_val = 0, phys_val = 0, val;
 
+#ifdef CONFIG_IOMMUFD
     /* Attempt registering device info to kernel. No-op if done already */
     vfio_register_bdf(pdev);
+#endif
 
     memcpy(&emu_bits, vdev->emulated_config_bits + addr, len);
     emu_bits = le32_to_cpu(emu_bits);
@@ -1440,8 +1444,10 @@ void vfio_pci_write_config(PCIDevice *pdev,
 
     trace_vfio_pci_write_config(vdev->vbasedev.name, addr, val, len);
 
+#ifdef CONFIG_IOMMUFD
     /* Attempt registering device info to kernel. No-op if done already */
     vfio_register_bdf(pdev);
+#endif
 
     /* Write everything to VFIO, let it filter out what we can't write */
     ret = vfio_pci_config_space_write(vdev, addr, len, &val_le);
@@ -3260,7 +3266,19 @@ bool vfio_pci_populate_device(VFIOPCIDevice *vdev, Error **errp)
 
 void vfio_pci_put_device(VFIOPCIDevice *vdev)
 {
-    qemu_del_vm_change_state_handler(vdev->vmstate);
+#ifdef CONFIG_IOMMUFD
+    /*
+     * Only TYPE_VFIO_PCI installs this handler (see vfio_pci_init()).  Sibling
+     * subclasses of TYPE_VFIO_PCI_DEVICE such as TYPE_VFIO_USER_PCI have their
+     * own instance_init and share this teardown path, so ->vmstate may be NULL
+     * here.  vfio_user_pci_realize() also calls us on its error path, before
+     * vfio_user_pci_finalize() calls us again, so clear the pointer too.
+     */
+    if (vdev->vmstate) {
+        qemu_del_vm_change_state_handler(vdev->vmstate);
+        vdev->vmstate = NULL;
+    }
+#endif
     vfio_display_finalize(vdev);
     vfio_bars_finalize(vdev);
 
@@ -4283,14 +4301,19 @@ post_reset:
     vfio_pci_post_reset(vdev);
 }
 
+#ifdef CONFIG_IOMMUFD
 static void vfio_register_bdf(PCIDevice *pci_dev)
 {
     VFIOPCIDevice *vdev = VFIO_PCI_DEVICE(pci_dev);
     PCIBus *bus = pci_get_bus(pci_dev);
     Error *err = NULL;
 
-    /* Already registered, or bus identifier is not yet assigned. Skip. */
+    /*
+     * Already registered (or permanently failed), or the bus identifier is not
+     * yet assigned. Skip.
+     */
     if (vdev->has_info_set ||
+        vdev->info_set_failed ||
         !vdev->vbasedev.iommufd_vdevice ||
         !vdev->is_running ||
         (!pci_bus_is_root(bus) &&
@@ -4299,6 +4322,12 @@ static void vfio_register_bdf(PCIDevice *pci_dev)
     }
 
     if (iommufd_vdevice_register(&vdev->vbasedev, &err)) {
+        /*
+         * Latch the failure: this runs from the config-space accessors, so
+         * without it every subsequent config access would re-report the same
+         * error.
+         */
+        vdev->info_set_failed = true;
         error_reportf_err(err, "Failed to register IOMMUFD vdevice for %s: ",
                           vdev->vbasedev.name);
         return;
@@ -4320,6 +4349,7 @@ static void vfio_register_bdf_notifier(void *opaque, bool running,
 
     vfio_register_bdf(opaque);
 }
+#endif
 
 static void vfio_pci_init(Object *obj)
 {
@@ -4335,8 +4365,11 @@ static void vfio_pci_init(Object *obj)
     vdev->host.slot = ~0U;
     vdev->host.function = ~0U;
 
+#ifdef CONFIG_IOMMUFD
     vdev->is_running = false;
     vdev->has_info_set = false;
+    vdev->info_set_failed = false;
+#endif
 
     vfio_device_init(vbasedev, VFIO_DEVICE_TYPE_PCI, &vfio_pci_ops,
                      DEVICE(vdev), false);
@@ -4354,8 +4387,10 @@ static void vfio_pci_init(Object *obj)
      */
     pci_dev->cap_present |= QEMU_PCI_SKIP_RESET_ON_CPR;
 
+#ifdef CONFIG_IOMMUFD
     vdev->vmstate = qemu_add_vm_change_state_handler_prio(
         vfio_register_bdf_notifier, obj, 10);
+#endif
 }
 
 static void vfio_pci_device_class_init(ObjectClass *klass, const void *data)
@@ -4586,7 +4621,8 @@ static void vfio_pci_class_init(ObjectClass *klass, const void *data)
                                           "Set host IOMMUFD backend device");
     object_class_property_set_description(klass, /* 10.0 */
                                           "iommufd-vdevice",
-                                          "Register the device with IOMMUFD VDEVICE");
+                                          "Register the device as an IOMMUFD "
+                                          "vDevice");
 #endif
     object_class_property_set_description(klass, /* 9.1 */
                                           "x-device-dirty-page-tracking",

--- a/hw/vfio/pci.c
+++ b/hw/vfio/pci.c
@@ -58,6 +58,7 @@ static KVMRouteChange vfio_route_change;
 static void vfio_disable_interrupts(VFIOPCIDevice *vdev);
 static void vfio_mmap_set_enabled(VFIOPCIDevice *vdev, bool enabled);
 static void vfio_msi_disable_common(VFIOPCIDevice *vdev);
+static void vfio_register_bdf(PCIDevice *pci_dev);
 
 /* Create new or reuse existing eventfd */
 static bool vfio_notifier_init(VFIOPCIDevice *vdev, EventNotifier *e,
@@ -1399,6 +1400,9 @@ uint32_t vfio_pci_read_config(PCIDevice *pdev, uint32_t addr, int len)
     VFIODevice *vbasedev = &vdev->vbasedev;
     uint32_t emu_bits = 0, emu_val = 0, phys_val = 0, val;
 
+    /* Attempt registering device info to kernel. No-op if done already */
+    vfio_register_bdf(pdev);
+
     memcpy(&emu_bits, vdev->emulated_config_bits + addr, len);
     emu_bits = le32_to_cpu(emu_bits);
 
@@ -1435,6 +1439,9 @@ void vfio_pci_write_config(PCIDevice *pdev,
     int ret;
 
     trace_vfio_pci_write_config(vdev->vbasedev.name, addr, val, len);
+
+    /* Attempt registering device info to kernel. No-op if done already */
+    vfio_register_bdf(pdev);
 
     /* Write everything to VFIO, let it filter out what we can't write */
     ret = vfio_pci_config_space_write(vdev, addr, len, &val_le);
@@ -3253,6 +3260,7 @@ bool vfio_pci_populate_device(VFIOPCIDevice *vdev, Error **errp)
 
 void vfio_pci_put_device(VFIOPCIDevice *vdev)
 {
+    qemu_del_vm_change_state_handler(vdev->vmstate);
     vfio_display_finalize(vdev);
     vfio_bars_finalize(vdev);
 
@@ -4275,6 +4283,43 @@ post_reset:
     vfio_pci_post_reset(vdev);
 }
 
+static void vfio_register_bdf(PCIDevice *pci_dev)
+{
+    VFIOPCIDevice *vdev = VFIO_PCI_DEVICE(pci_dev);
+    PCIBus *bus = pci_get_bus(pci_dev);
+    Error *err = NULL;
+
+    /* Already registered, or bus identifier is not yet assigned. Skip. */
+    if (vdev->has_info_set ||
+        !vdev->vbasedev.iommufd_vdevice ||
+        !vdev->is_running ||
+        (!pci_bus_is_root(bus) &&
+         (pci_bus_num(bus) == 0))) {
+        return;
+    }
+
+    vdev->has_info_set = true;
+
+    if (iommufd_vdevice_register(&vdev->vbasedev, &err)) {
+        error_reportf_err(err, "Failed to register IOMMUFD vdevice for %s: ",
+                          vdev->vbasedev.name);
+    }
+}
+
+static void vfio_register_bdf_notifier(void *opaque, bool running,
+                                       RunState state)
+{
+    VFIOPCIDevice *vdev = VFIO_PCI_DEVICE(opaque);
+
+    if (!running) {
+        return;
+    }
+
+    vdev->is_running = true;
+
+    vfio_register_bdf(opaque);
+}
+
 static void vfio_pci_init(Object *obj)
 {
     PCIDevice *pci_dev = PCI_DEVICE(obj);
@@ -4288,6 +4333,9 @@ static void vfio_pci_init(Object *obj)
     vdev->host.bus = ~0U;
     vdev->host.slot = ~0U;
     vdev->host.function = ~0U;
+
+    vdev->is_running = false;
+    vdev->has_info_set = false;
 
     vfio_device_init(vbasedev, VFIO_DEVICE_TYPE_PCI, &vfio_pci_ops,
                      DEVICE(vdev), false);
@@ -4304,6 +4352,9 @@ static void vfio_pci_init(Object *obj)
      * may be lost.
      */
     pci_dev->cap_present |= QEMU_PCI_SKIP_RESET_ON_CPR;
+
+    vdev->vmstate = qemu_add_vm_change_state_handler_prio(
+        vfio_register_bdf_notifier, obj, 10);
 }
 
 static void vfio_pci_device_class_init(ObjectClass *klass, const void *data)
@@ -4401,6 +4452,8 @@ static const Property vfio_pci_properties[] = {
 #ifdef CONFIG_IOMMUFD
     DEFINE_PROP_LINK("iommufd", VFIOPCIDevice, vbasedev.iommufd,
                      TYPE_IOMMUFD_BACKEND, IOMMUFDBackend *),
+    DEFINE_PROP_BOOL("iommufd-vdevice", VFIOPCIDevice, vbasedev.iommufd_vdevice,
+                     false),
 #endif
     DEFINE_PROP_BOOL("skip-vsc-check", VFIOPCIDevice, skip_vsc_check, true),
     DEFINE_PROP_UINT16("x-vpasid-cap-offset", VFIOPCIDevice,
@@ -4530,6 +4583,9 @@ static void vfio_pci_class_init(ObjectClass *klass, const void *data)
     object_class_property_set_description(klass, /* 9.0 */
                                           "iommufd",
                                           "Set host IOMMUFD backend device");
+    object_class_property_set_description(klass, /* 10.0 */
+                                          "iommufd-vdevice",
+                                          "Register the device with IOMMUFD VDEVICE");
 #endif
     object_class_property_set_description(klass, /* 9.1 */
                                           "x-device-dirty-page-tracking",

--- a/hw/vfio/pci.c
+++ b/hw/vfio/pci.c
@@ -4298,12 +4298,13 @@ static void vfio_register_bdf(PCIDevice *pci_dev)
         return;
     }
 
-    vdev->has_info_set = true;
-
     if (iommufd_vdevice_register(&vdev->vbasedev, &err)) {
         error_reportf_err(err, "Failed to register IOMMUFD vdevice for %s: ",
                           vdev->vbasedev.name);
+        return;
     }
+
+    vdev->has_info_set = true;
 }
 
 static void vfio_register_bdf_notifier(void *opaque, bool running,

--- a/hw/vfio/pci.h
+++ b/hw/vfio/pci.h
@@ -203,10 +203,13 @@ struct VFIOPCIDevice {
     bool clear_parent_atomics_on_exit;
     bool skip_vsc_check;
     uint16_t vpasid_cap_offset;
+    bool has_info_set;
+    bool is_running;
     VFIODisplay *dpy;
     Notifier irqchip_change_notifier;
     VFIOPCICPR cpr;
     VFIOCXL cxl;
+    VMChangeStateEntry *vmstate;
 };
 
 /* Use uin32_t for vendor & device so PCI_ANY_ID expands and cannot match hw */

--- a/hw/vfio/pci.h
+++ b/hw/vfio/pci.h
@@ -204,6 +204,7 @@ struct VFIOPCIDevice {
     bool skip_vsc_check;
     uint16_t vpasid_cap_offset;
     bool has_info_set;
+    bool info_set_failed;
     bool is_running;
     VFIODisplay *dpy;
     Notifier irqchip_change_notifier;

--- a/hw/vfio/trace-events
+++ b/hw/vfio/trace-events
@@ -189,6 +189,10 @@ iommufd_cdev_fail_attach_existing_container(const char *msg) " %s"
 iommufd_cdev_alloc_ioas(int iommufd, int ioas_id) " [iommufd=%d] new IOMMUFD container with ioasid=%d"
 iommufd_cdev_device_info(char *name, int devfd, int num_irqs, int num_regions, int flags) " %s (%d) num_irqs=%d num_regions=%d flags=%d"
 iommufd_cdev_pci_hot_reset_dep_devices(int domain, int bus, int slot, int function, int dev_id) "\t%04x:%02x:%02x.%x devid %d"
+iommufd_tsm_op_failed(uint32_t rid, uint32_t op, int err) " rid 0x%04x op %u failed, errno=%d"
+iommufd_tsm_guest_request_failed(uint32_t vdevice_id, uint32_t scope, int err) " vdevice_id %u scope %u failed, errno=%d"
+iommufd_tsm_guest_request_bad_residue(uint32_t vdevice_id, int residue, uint32_t resp_len) " vdevice_id %u returned invalid residue %d for a %u-byte response"
+iommufd_tsm_dev_memmap(uint32_t rid, uint64_t gpa_base, uint64_t gpa_top, uint64_t pa_base, bool ok) " rid 0x%04x [0x%"PRIx64", 0x%"PRIx64") pa 0x%"PRIx64" accepted=%d"
 
 # cpr-iommufd.c
 vfio_cpr_find_device(uint32_t ioas_id, int devid, uint32_t hwpt_id) "ioas_id %u, devid %d, hwpt_id %u"

--- a/hw/vfio/vfio-iommufd.h
+++ b/hw/vfio/vfio-iommufd.h
@@ -15,6 +15,8 @@ typedef struct VFIODevice VFIODevice;
 
 typedef struct VFIOIOASHwpt {
     uint32_t hwpt_id;
+    uint32_t nested_hwpt_id;
+    uint32_t viommu_id;
     uint32_t hwpt_flags;
     QLIST_HEAD(, VFIODevice) device_list;
     QLIST_ENTRY(VFIOIOASHwpt) next;

--- a/hw/virtio/virtio-mmio.c
+++ b/hw/virtio/virtio-mmio.c
@@ -28,6 +28,7 @@
 #include "migration/qemu-file-types.h"
 #include "qemu/host-utils.h"
 #include "qemu/module.h"
+#include "system/address-spaces.h"
 #include "system/kvm.h"
 #include "system/replay.h"
 #include "hw/virtio/virtio-mmio.h"
@@ -761,6 +762,27 @@ static void virtio_mmio_pre_plugged(DeviceState *d, Error **errp)
     }
 }
 
+static AddressSpace *virtio_mmio_get_dma_as(DeviceState *d)
+{
+    VirtIOMMIOProxy *proxy = VIRTIO_MMIO(d);
+
+    return proxy->dma_as ?: &address_space_memory;
+}
+
+static bool virtio_mmio_iommu_enabled(DeviceState *d)
+{
+    return virtio_mmio_get_dma_as(d) != &address_space_memory;
+}
+
+void virtio_mmio_set_dma_as(DeviceState *d, AddressSpace *dma_as)
+{
+    VirtIOMMIOProxy *proxy = VIRTIO_MMIO(d);
+
+    assert(!d->realized);
+    assert(dma_as);
+    proxy->dma_as = dma_as;
+}
+
 /* virtio-mmio device */
 
 static const Property virtio_mmio_properties[] = {
@@ -868,6 +890,8 @@ static void virtio_mmio_bus_class_init(ObjectClass *klass, const void *data)
     k->ioeventfd_assign = virtio_mmio_ioeventfd_assign;
     k->pre_plugged = virtio_mmio_pre_plugged;
     k->vmstate_change = virtio_mmio_vmstate_change;
+    k->get_dma_as = virtio_mmio_get_dma_as;
+    k->iommu_enabled = virtio_mmio_iommu_enabled;
     k->has_variable_vring_alignment = true;
     bus_class->max_dev = 1;
     bus_class->get_dev_path = virtio_mmio_bus_get_dev_path;

--- a/include/hw/arm/boot.h
+++ b/include/hw/arm/boot.h
@@ -112,6 +112,10 @@ struct arm_boot_info {
      */
     bool firmware_loaded;
 
+    /* Used when loading firmware into RAM */
+    hwaddr firmware_base;
+    hwaddr firmware_max_size;
+
     /* Address at which board specific loader/setup code exists. If enabled,
      * this code-blob will run before anything else. It must return to the
      * caller via the link register. There is no stack set up. Enabled by
@@ -135,6 +139,11 @@ struct arm_boot_info {
 
     /* CPU having load the kernel and that should be the first to boot.  */
     ARMCPU *primary_cpu;
+
+    /*
+     * Confidential guest boot loads everything into RAM so it can be measured.
+     */
+    bool confidential;
 };
 
 /**

--- a/include/hw/arm/virt.h
+++ b/include/hw/arm/virt.h
@@ -156,7 +156,8 @@ struct VirtMachineState {
     bool virt;
     bool ras;
     bool mte;
-    OnOffAuto dtb_randomness;
+    bool dtb_randomness;
+    bool dtb_randomness_set;
     bool second_ns_uart_present;
     OnOffAuto acpi;
     VirtGICType gic_version;

--- a/include/hw/arm/virt.h
+++ b/include/hw/arm/virt.h
@@ -156,7 +156,7 @@ struct VirtMachineState {
     bool virt;
     bool ras;
     bool mte;
-    bool dtb_randomness;
+    OnOffAuto dtb_randomness;
     bool second_ns_uart_present;
     OnOffAuto acpi;
     VirtGICType gic_version;

--- a/include/hw/core/loader.h
+++ b/include/hw/core/loader.h
@@ -342,6 +342,23 @@ void *rom_ptr_for_as(AddressSpace *as, hwaddr addr, size_t size);
 ssize_t rom_add_vga(const char *file);
 ssize_t rom_add_option(const char *file, int32_t bootindex);
 
+typedef struct RomLoaderNotifyData {
+    /* Address of the blob in guest memory */
+    hwaddr addr;
+    /* Length of the blob */
+    size_t len;
+    /* Address space of the blob */
+    AddressSpace *as;
+} RomLoaderNotifyData;
+
+/**
+ * rom_add_load_notifier - Add a notifier for loaded images
+ *
+ * Add a notifier that will be invoked with a RomLoaderNotifyData structure for
+ * each blob loaded into guest memory, after the blob is loaded.
+ */
+void rom_add_load_notifier(Notifier *notifier);
+
 /* This is the usual maximum in uboot, so if a uImage overflows this, it would
  * overflow on real hardware too. */
 #define UBOOT_MAX_DECOMPRESSED_BYTES (64 << 20)

--- a/include/hw/vfio/vfio-device.h
+++ b/include/hw/vfio/vfio-device.h
@@ -85,6 +85,8 @@ typedef struct VFIODevice {
     bool iommu_dirty_tracking;
     HostIOMMUDevice *hiod;
     int devid;
+    int vdevice_id;
+    bool iommufd_vdevice;
     IOMMUFDBackend *iommufd;
     VFIOIOASHwpt *hwpt;
     QLIST_ENTRY(VFIODevice) hwpt_next;
@@ -170,6 +172,8 @@ VFIODevice *vfio_get_vfio_device(Object *obj);
 
 typedef QLIST_HEAD(VFIODeviceList, VFIODevice) VFIODeviceList;
 extern VFIODeviceList vfio_device_list;
+
+VFIODevice *vfio_find_bdf(uint64_t sbdf);
 
 #ifdef CONFIG_LINUX
 /*

--- a/include/hw/vfio/vfio-device.h
+++ b/include/hw/vfio/vfio-device.h
@@ -173,6 +173,7 @@ VFIODevice *vfio_get_vfio_device(Object *obj);
 typedef QLIST_HEAD(VFIODeviceList, VFIODevice) VFIODeviceList;
 extern VFIODeviceList vfio_device_list;
 
+/* Caller must hold the BQL while using the returned device. */
 VFIODevice *vfio_find_bdf(uint32_t rid);
 
 #ifdef CONFIG_LINUX

--- a/include/hw/vfio/vfio-device.h
+++ b/include/hw/vfio/vfio-device.h
@@ -173,7 +173,7 @@ VFIODevice *vfio_get_vfio_device(Object *obj);
 typedef QLIST_HEAD(VFIODeviceList, VFIODevice) VFIODeviceList;
 extern VFIODeviceList vfio_device_list;
 
-VFIODevice *vfio_find_bdf(uint64_t sbdf);
+VFIODevice *vfio_find_bdf(uint32_t rid);
 
 #ifdef CONFIG_LINUX
 /*

--- a/include/hw/virtio/virtio-mmio.h
+++ b/include/hw/virtio/virtio-mmio.h
@@ -64,11 +64,14 @@ struct VirtIOMMIOProxy {
     uint32_t host_features_sel;
     uint32_t guest_features_sel;
     uint32_t guest_page_shift;
+    AddressSpace *dma_as;
     /* virtio-bus */
     VirtioBusState bus;
     /* Fields only used for non-legacy (v2) devices */
     uint32_t guest_features[2];
     VirtIOMMIOQueue vqs[VIRTIO_QUEUE_MAX];
 };
+
+void virtio_mmio_set_dma_as(DeviceState *dev, AddressSpace *dma_as);
 
 #endif

--- a/include/system/iommufd.h
+++ b/include/system/iommufd.h
@@ -131,26 +131,28 @@ bool iommufd_backend_invalidate_cache(IOMMUFDBackend *be, uint32_t id,
 bool iommufd_change_process_capable(IOMMUFDBackend *be);
 bool iommufd_change_process(IOMMUFDBackend *be, Error **errp);
 
-int iommufd_vdevice_register(VFIODevice *vbasedev, Error **errp);
-int iommufd_tsm_da_set_tdi_state_run(unsigned int vdev_id);
-int iommufd_tsm_get_da_object_size(unsigned int vdev_id,
-       unsigned int object_type,
-       unsigned int *object_size);
-int iommufd_tsm_da_object_read(unsigned int vdev_id,
-       unsigned int object_type,
-       unsigned long offset,
-       void *buf,
-       unsigned long max_len,
-       unsigned int *resp_len);
-int iommufd_tsm_da_get_interface_report(unsigned int vdev_id);
 struct rhi_vdev_measurement_params;
-int iommufd_tsm_da_get_measurement(unsigned int vdev_id,
-       struct rhi_vdev_measurement_params *param);
-bool iommufd_tsm_dev_memmap_exit(unsigned long vdev_id,
-    unsigned long gpa_base, unsigned long gpa_top,
-    unsigned long pa_base);
-int iommufd_tsm_bind(unsigned long vdev_id);
-int iommufd_tsm_unbind(unsigned long vdev_id);
+
+/*
+ * Arm RME device assignment.  @rid is the guest-visible Routing ID of the
+ * assigned device: PCI segment in bits [31:16], BDF in bits [15:0].  All of
+ * these return 0 (or true) on success, and -ENODEV if @rid does not name a
+ * device that has been registered as an iommufd vDevice.
+ */
+int iommufd_vdevice_register(VFIODevice *vbasedev, Error **errp);
+int iommufd_tsm_bind(uint32_t rid);
+int iommufd_tsm_unbind(uint32_t rid);
+int iommufd_tsm_da_set_tdi_state_run(uint32_t rid);
+int iommufd_tsm_get_da_object_size(uint32_t rid, uint32_t object_type,
+                                   uint32_t *object_size);
+int iommufd_tsm_da_object_read(uint32_t rid, uint32_t object_type,
+                               uint64_t offset, void *buf, uint32_t max_len,
+                               uint32_t *resp_len);
+int iommufd_tsm_da_get_interface_report(uint32_t rid);
+int iommufd_tsm_da_get_measurement(uint32_t rid,
+                                   struct rhi_vdev_measurement_params *param);
+bool iommufd_tsm_dev_memmap_exit(uint32_t rid, uint64_t gpa_base,
+                                 uint64_t gpa_top, uint64_t pa_base);
 
 #define TYPE_HOST_IOMMU_DEVICE_IOMMUFD TYPE_HOST_IOMMU_DEVICE "-iommufd"
 OBJECT_DECLARE_TYPE(HostIOMMUDeviceIOMMUFD, HostIOMMUDeviceIOMMUFDClass,

--- a/include/system/iommufd.h
+++ b/include/system/iommufd.h
@@ -19,6 +19,8 @@
 #include "system/ram_addr.h"
 #include "system/host_iommu_device.h"
 
+typedef struct VFIODevice VFIODevice;
+
 #define TYPE_IOMMUFD_BACKEND "iommufd"
 OBJECT_DECLARE_TYPE(IOMMUFDBackend, IOMMUFDBackendClass, IOMMUFD_BACKEND)
 
@@ -128,6 +130,27 @@ bool iommufd_backend_invalidate_cache(IOMMUFDBackend *be, uint32_t id,
 
 bool iommufd_change_process_capable(IOMMUFDBackend *be);
 bool iommufd_change_process(IOMMUFDBackend *be, Error **errp);
+
+int iommufd_vdevice_register(VFIODevice *vbasedev, Error **errp);
+int iommufd_tsm_da_set_tdi_state_run(unsigned int vdev_id);
+int iommufd_tsm_get_da_object_size(unsigned int vdev_id,
+       unsigned int object_type,
+       unsigned int *object_size);
+int iommufd_tsm_da_object_read(unsigned int vdev_id,
+       unsigned int object_type,
+       unsigned long offset,
+       void *buf,
+       unsigned long max_len,
+       unsigned int *resp_len);
+int iommufd_tsm_da_get_interface_report(unsigned int vdev_id);
+struct rhi_vdev_measurement_params;
+int iommufd_tsm_da_get_measurement(unsigned int vdev_id,
+       struct rhi_vdev_measurement_params *param);
+bool iommufd_tsm_dev_memmap_exit(unsigned long vdev_id,
+    unsigned long gpa_base, unsigned long gpa_top,
+    unsigned long pa_base);
+int iommufd_tsm_bind(unsigned long vdev_id);
+int iommufd_tsm_unbind(unsigned long vdev_id);
 
 #define TYPE_HOST_IOMMU_DEVICE_IOMMUFD TYPE_HOST_IOMMU_DEVICE "-iommufd"
 OBJECT_DECLARE_TYPE(HostIOMMUDeviceIOMMUFD, HostIOMMUDeviceIOMMUFDClass,

--- a/include/system/kvm.h
+++ b/include/system/kvm.h
@@ -553,6 +553,8 @@ bool kvm_dirty_ring_enabled(void);
 
 uint32_t kvm_dirty_ring_size(void);
 
+bool kvm_guest_state_protected(void);
+
 void kvm_mark_guest_state_protected(void);
 
 /**

--- a/include/system/memory.h
+++ b/include/system/memory.h
@@ -2862,6 +2862,19 @@ bool address_space_access_valid(AddressSpace *as, hwaddr addr, hwaddr len,
  */
 bool address_space_is_io(AddressSpace *as, hwaddr addr);
 
+/**
+ * address_space_range_is_ram: check whether a guest physical address range
+ *                             within an address space resolves entirely to RAM.
+ *
+ * @as: #AddressSpace to be accessed
+ * @addr: address within that address space
+ * @size: number of bytes in the range starting at @addr
+ *
+ * Returns true if every byte in [@addr, @addr + @size) maps to a RAM
+ * MemoryRegion, false otherwise.
+ */
+bool address_space_range_is_ram(AddressSpace *as, hwaddr addr, hwaddr size);
+
 /* address_space_map: map a physical memory region into a host virtual address
  *
  * May map a subset of the requested range, given by and returned in @plen.

--- a/linux-headers/asm-arm64/kvm.h
+++ b/linux-headers/asm-arm64/kvm.h
@@ -208,6 +208,15 @@ struct kvm_arm_counter_offset {
 	__u64 reserved;
 };
 
+#define KVM_ARM_RMI_POPULATE_FLAGS_MEASURE     (1 << 0)
+struct kvm_arm_rmi_populate {
+	__u64 base;
+	__u64 size;
+	__u64 source_uaddr;
+	__u32 flags;
+	__u32 reserved;
+};
+
 #define KVM_ARM_TAGS_TO_GUEST		0
 #define KVM_ARM_TAGS_FROM_GUEST		1
 

--- a/linux-headers/asm-arm64/kvm.h
+++ b/linux-headers/asm-arm64/kvm.h
@@ -552,4 +552,7 @@ struct reg_mask_range {
 
 #endif
 
+/* arm specific KVM_EXIT_ARM64_TIO nr value*/
+#define RMI_EXIT_VDEV_MAP		0x08
+
 #endif /* __ARM_KVM_H__ */

--- a/linux-headers/linux/arm-smccc.h
+++ b/linux-headers/linux/arm-smccc.h
@@ -1,0 +1,348 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * Copied from $linux/include/linux/arm-smccc.h
+ *
+ * WARNING: this is a copy of a *non-UAPI* kernel header, and it has been
+ * modified locally (see the SMC_RHI_CALL / RHI_DA_* block near the end).
+ * scripts/update-linux-headers.sh neither generates nor refreshes it.  The
+ * QEMU-local additions belong outside linux-headers/ and must be moved before
+ * this work is posted upstream.
+ */
+#ifndef __LINUX_ARM_SMCCC_H
+#define __LINUX_ARM_SMCCC_H
+
+#include <linux/const.h>
+#include <linux/types.h>
+
+/*
+ * This file provides common defines for ARM SMC Calling Convention as
+ * specified in
+ * https://developer.arm.com/docs/den0028/latest
+ *
+ * This code is up-to-date with version DEN 0028 C
+ */
+
+#define ARM_SMCCC_STD_CALL	        _AC(0,U)
+#define ARM_SMCCC_FAST_CALL	        _AC(1,U)
+#define ARM_SMCCC_TYPE_SHIFT		31
+
+#define ARM_SMCCC_SMC_32		0
+#define ARM_SMCCC_SMC_64		1
+#define ARM_SMCCC_CALL_CONV_SHIFT	30
+
+#define ARM_SMCCC_OWNER_MASK		0x3F
+#define ARM_SMCCC_OWNER_SHIFT		24
+
+#define ARM_SMCCC_FUNC_MASK		0xFFFF
+
+#define ARM_SMCCC_IS_FAST_CALL(smc_val)	\
+	((smc_val) & (ARM_SMCCC_FAST_CALL << ARM_SMCCC_TYPE_SHIFT))
+#define ARM_SMCCC_IS_64(smc_val) \
+	((smc_val) & (ARM_SMCCC_SMC_64 << ARM_SMCCC_CALL_CONV_SHIFT))
+#define ARM_SMCCC_FUNC_NUM(smc_val)	((smc_val) & ARM_SMCCC_FUNC_MASK)
+#define ARM_SMCCC_OWNER_NUM(smc_val) \
+	(((smc_val) >> ARM_SMCCC_OWNER_SHIFT) & ARM_SMCCC_OWNER_MASK)
+
+#define ARM_SMCCC_CALL_VAL(type, calling_convention, owner, func_num) \
+	(((type) << ARM_SMCCC_TYPE_SHIFT) | \
+	((calling_convention) << ARM_SMCCC_CALL_CONV_SHIFT) | \
+	(((owner) & ARM_SMCCC_OWNER_MASK) << ARM_SMCCC_OWNER_SHIFT) | \
+	((func_num) & ARM_SMCCC_FUNC_MASK))
+
+#define ARM_SMCCC_OWNER_ARCH		0
+#define ARM_SMCCC_OWNER_CPU		1
+#define ARM_SMCCC_OWNER_SIP		2
+#define ARM_SMCCC_OWNER_OEM		3
+#define ARM_SMCCC_OWNER_STANDARD	4
+#define ARM_SMCCC_OWNER_STANDARD_HYP	5
+#define ARM_SMCCC_OWNER_VENDOR_HYP	6
+#define ARM_SMCCC_OWNER_TRUSTED_APP	48
+#define ARM_SMCCC_OWNER_TRUSTED_APP_END	49
+#define ARM_SMCCC_OWNER_TRUSTED_OS	50
+#define ARM_SMCCC_OWNER_TRUSTED_OS_END	63
+
+#define ARM_SMCCC_FUNC_QUERY_CALL_UID  0xff01
+
+#define ARM_SMCCC_QUIRK_NONE		0
+#define ARM_SMCCC_QUIRK_QCOM_A6		1 /* Save/restore register a6 */
+
+#define ARM_SMCCC_VERSION_1_0		0x10000
+#define ARM_SMCCC_VERSION_1_1		0x10001
+#define ARM_SMCCC_VERSION_1_2		0x10002
+#define ARM_SMCCC_VERSION_1_3		0x10003
+
+#define ARM_SMCCC_1_3_SVE_HINT		0x10000
+#define ARM_SMCCC_CALL_HINTS		ARM_SMCCC_1_3_SVE_HINT
+
+
+#define ARM_SMCCC_VERSION_FUNC_ID					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   0, 0)
+
+#define ARM_SMCCC_ARCH_FEATURES_FUNC_ID					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   0, 1)
+
+#define ARM_SMCCC_ARCH_SOC_ID						\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   0, 2)
+
+#define ARM_SMCCC_ARCH_WORKAROUND_1					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   0, 0x8000)
+
+#define ARM_SMCCC_ARCH_WORKAROUND_2					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   0, 0x7fff)
+
+#define ARM_SMCCC_ARCH_WORKAROUND_3					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   0, 0x3fff)
+
+#define ARM_SMCCC_VENDOR_HYP_CALL_UID_FUNC_ID				\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_FUNC_QUERY_CALL_UID)
+
+
+/* KVM "vendor specific" services */
+#define ARM_SMCCC_KVM_FUNC_FEATURES		0
+#define ARM_SMCCC_KVM_FUNC_PTP			1
+/* Start of pKVM hypercall range */
+#define ARM_SMCCC_KVM_FUNC_HYP_MEMINFO		2
+#define ARM_SMCCC_KVM_FUNC_MEM_SHARE		3
+#define ARM_SMCCC_KVM_FUNC_MEM_UNSHARE		4
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_5		5
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_6		6
+#define ARM_SMCCC_KVM_FUNC_MMIO_GUARD		7
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_8		8
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_9		9
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_10		10
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_11		11
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_12		12
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_13		13
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_14		14
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_15		15
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_16		16
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_17		17
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_18		18
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_19		19
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_20		20
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_21		21
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_22		22
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_23		23
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_24		24
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_25		25
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_26		26
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_27		27
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_28		28
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_29		29
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_30		30
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_31		31
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_32		32
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_33		33
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_34		34
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_35		35
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_36		36
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_37		37
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_38		38
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_39		39
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_40		40
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_41		41
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_42		42
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_43		43
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_44		44
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_45		45
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_46		46
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_47		47
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_48		48
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_49		49
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_50		50
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_51		51
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_52		52
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_53		53
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_54		54
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_55		55
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_56		56
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_57		57
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_58		58
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_59		59
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_60		60
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_61		61
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_62		62
+#define ARM_SMCCC_KVM_FUNC_PKVM_RESV_63		63
+/* End of pKVM hypercall range */
+#define ARM_SMCCC_KVM_FUNC_DISCOVER_IMPL_VER	64
+#define ARM_SMCCC_KVM_FUNC_DISCOVER_IMPL_CPUS	65
+
+#define ARM_SMCCC_KVM_FUNC_FEATURES_2		127
+#define ARM_SMCCC_KVM_NUM_FUNCS			128
+
+#define ARM_SMCCC_VENDOR_HYP_KVM_FEATURES_FUNC_ID			\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_FEATURES)
+
+#define SMCCC_ARCH_WORKAROUND_RET_UNAFFECTED	1
+
+/*
+ * ptp_kvm is a feature used for time sync between vm and host.
+ * ptp_kvm module in guest kernel will get service from host using
+ * this hypercall ID.
+ */
+#define ARM_SMCCC_VENDOR_HYP_KVM_PTP_FUNC_ID				\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_32,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_PTP)
+
+#define ARM_SMCCC_VENDOR_HYP_KVM_HYP_MEMINFO_FUNC_ID			\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_64,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_HYP_MEMINFO)
+
+#define ARM_SMCCC_VENDOR_HYP_KVM_MEM_SHARE_FUNC_ID			\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_64,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_MEM_SHARE)
+
+#define ARM_SMCCC_VENDOR_HYP_KVM_MEM_UNSHARE_FUNC_ID			\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_64,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_MEM_UNSHARE)
+
+#define ARM_SMCCC_VENDOR_HYP_KVM_MMIO_GUARD_FUNC_ID			\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_64,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_MMIO_GUARD)
+
+#define ARM_SMCCC_VENDOR_HYP_KVM_DISCOVER_IMPL_VER_FUNC_ID		\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_64,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_DISCOVER_IMPL_VER)
+
+#define ARM_SMCCC_VENDOR_HYP_KVM_DISCOVER_IMPL_CPUS_FUNC_ID		\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,				\
+			   ARM_SMCCC_SMC_64,				\
+			   ARM_SMCCC_OWNER_VENDOR_HYP,			\
+			   ARM_SMCCC_KVM_FUNC_DISCOVER_IMPL_CPUS)
+
+/* ptp_kvm counter type ID */
+#define KVM_PTP_VIRT_COUNTER			0
+#define KVM_PTP_PHYS_COUNTER			1
+
+/* Paravirtualised time calls (defined by ARM DEN0057A) */
+#define ARM_SMCCC_HV_PV_TIME_FEATURES				\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,			\
+			   ARM_SMCCC_SMC_64,			\
+			   ARM_SMCCC_OWNER_STANDARD_HYP,	\
+			   0x20)
+
+#define ARM_SMCCC_HV_PV_TIME_ST					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,			\
+			   ARM_SMCCC_SMC_64,			\
+			   ARM_SMCCC_OWNER_STANDARD_HYP,	\
+			   0x21)
+
+/* TRNG entropy source calls (defined by ARM DEN0098) */
+#define ARM_SMCCC_TRNG_VERSION					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,			\
+			   ARM_SMCCC_SMC_32,			\
+			   ARM_SMCCC_OWNER_STANDARD,		\
+			   0x50)
+
+#define ARM_SMCCC_TRNG_FEATURES					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,			\
+			   ARM_SMCCC_SMC_32,			\
+			   ARM_SMCCC_OWNER_STANDARD,		\
+			   0x51)
+
+#define ARM_SMCCC_TRNG_GET_UUID					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,			\
+			   ARM_SMCCC_SMC_32,			\
+			   ARM_SMCCC_OWNER_STANDARD,		\
+			   0x52)
+
+#define ARM_SMCCC_TRNG_RND32					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,			\
+			   ARM_SMCCC_SMC_32,			\
+			   ARM_SMCCC_OWNER_STANDARD,		\
+			   0x53)
+
+#define ARM_SMCCC_TRNG_RND64					\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,			\
+			   ARM_SMCCC_SMC_64,			\
+			   ARM_SMCCC_OWNER_STANDARD,		\
+			   0x53)
+
+#define SMC_RHI_CALL(func)				\
+	ARM_SMCCC_CALL_VAL(ARM_SMCCC_FAST_CALL,		\
+			   ARM_SMCCC_SMC_64,		\
+			   ARM_SMCCC_OWNER_STANDARD_HYP,\
+			   (func))
+
+#define RHI_DA_FEATURE_OBJECT_SIZE		0b000001
+#define RHI_DA_FEATURE_OBJECT_READ		0b000010
+#define RHI_DA_FEATURE_VDEV_CONTINUE		0b000100
+#define RHI_DA_FEATURE_VDEV_GET_MEASUREMENT	0b001000
+#define RHI_DA_FEATURE_VDEV_GET_INTF_REPORT	0b010000
+#define RHI_DA_FEATURE_VDEV_SET_TDI_STATE	0b100000
+
+#define RHI_DA_BASE_FEATURE	(RHI_DA_FEATURE_OBJECT_SIZE |		\
+				 RHI_DA_FEATURE_OBJECT_READ |		\
+				 RHI_DA_FEATURE_VDEV_GET_INTF_REPORT |	\
+				 RHI_DA_FEATURE_VDEV_GET_MEASUREMENT |	\
+				 RHI_DA_FEATURE_VDEV_SET_TDI_STATE)
+#define RHI_DA_FEATURES			SMC_RHI_CALL(0x004B)
+#define RHI_DA_OBJECT_SIZE		SMC_RHI_CALL(0x004C)
+#define RHI_DA_OBJECT_READ		SMC_RHI_CALL(0x004D)
+
+#define RHI_DA_VDEV_GET_INTERFACE_REPORT SMC_RHI_CALL(0x0053)
+struct rhi_vdev_measurement_params {
+	union {
+		__u64 flags;
+		__u8 padding0[256];
+	};
+	union {
+		__u8 nonce[32];
+		__u8 padding2[256];
+	};
+};
+#define RHI_DA_VDEV_GET_MEASUREMENTS	SMC_RHI_CALL(0x0052)
+#define RHI_DA_VDEV_SET_TDI_STATE	SMC_RHI_CALL(0x0054)
+
+/*
+ * Return codes defined in ARM DEN 0070A
+ * ARM DEN 0070A is now merged/consolidated into ARM DEN 0028 C
+ */
+#define SMCCC_RET_SUCCESS			0
+#define SMCCC_RET_NOT_SUPPORTED			-1
+#define SMCCC_RET_NOT_REQUIRED			-2
+#define SMCCC_RET_INVALID_PARAMETER		-3
+
+/**
+ * struct arm_smccc_res - Result from SMC/HVC call
+ * @a0-a3 result values from registers 0 to 3
+ */
+struct arm_smccc_res {
+	unsigned long a0;
+	unsigned long a1;
+	unsigned long a2;
+	unsigned long a3;
+};
+
+#endif /*__LINUX_ARM_SMCCC_H*/

--- a/linux-headers/linux/iommufd.h
+++ b/linux-headers/linux/iommufd.h
@@ -57,6 +57,8 @@ enum {
 	IOMMUFD_CMD_IOAS_CHANGE_PROCESS = 0x92,
 	IOMMUFD_CMD_VEVENTQ_ALLOC = 0x93,
 	IOMMUFD_CMD_HW_QUEUE_ALLOC = 0x94,
+	IOMMUFD_CMD_VDEVICE_TSM_OP = 0x95,
+	IOMMUFD_CMD_VDEVICE_TSM_GUEST_REQUEST = 0x96,
 };
 
 /**
@@ -1014,6 +1016,7 @@ enum iommu_viommu_type {
 	IOMMU_VIOMMU_TYPE_DEFAULT = 0,
 	IOMMU_VIOMMU_TYPE_ARM_SMMUV3 = 1,
 	IOMMU_VIOMMU_TYPE_TEGRA241_CMDQV = 2,
+	IOMMU_VIOMMU_TYPE_ARM_REALM_SMMUV3 = 3,
 };
 
 /**
@@ -1299,4 +1302,27 @@ struct iommu_hw_queue_alloc {
 	__aligned_u64 length;
 };
 #define IOMMU_HW_QUEUE_ALLOC _IO(IOMMUFD_TYPE, IOMMUFD_CMD_HW_QUEUE_ALLOC)
+
+struct iommu_vdevice_tsm_op{
+	__u32 size;
+	__u32 op;
+	__u32 flags;
+	__u32 vdevice_id;
+};
+#define IOMMU_VDEVICE_TSM_OP	_IO(IOMMUFD_TYPE, IOMMUFD_CMD_VDEVICE_TSM_OP)
+#define IOMMU_VDEVICE_TSM_BIND		0x1
+#define IOMMU_VDEVICE_TSM_UNBIND	0x2
+
+struct iommu_vdevice_tsm_guest_request {
+	__u32 size;
+	__u32 vdevice_id;
+	__u32 scope;
+	__u32 req_len;
+	__u32 resp_len;
+	__u32 __reserved;
+	__aligned_u64 req_uptr;
+	__aligned_u64 resp_uptr;
+};
+#define IOMMU_VDEVICE_TSM_GUEST_REQUEST _IO(IOMMUFD_TYPE, IOMMUFD_CMD_VDEVICE_TSM_GUEST_REQUEST)
+
 #endif

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -180,6 +180,7 @@ struct kvm_xen_exit {
 #define KVM_EXIT_MEMORY_FAULT     39
 #define KVM_EXIT_TDX              40
 #define KVM_EXIT_ARM_SEA          41
+#define KVM_EXIT_ARM64_TIO	  44
 
 /* For KVM_EXIT_INTERNAL_ERROR */
 /* Emulate instruction failed. */
@@ -474,6 +475,16 @@ struct kvm_run {
 			__u64 gva;
 			__u64 gpa;
 		} arm_sea;
+		/* KVM_EXIT_ARM64_TIO*/
+		struct {
+			__u64 flags;
+			__u64 nr;
+			__u64 vdev_id;
+			__u64 gpa_base;
+			__u64 gpa_top; /* input and output */
+			__u64 pa_base;
+			__u64 response;
+		} cca_exit;
 		/* Fix the size of the union. */
 		char padding[256];
 	};

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -677,10 +677,20 @@ struct kvm_enable_cap {
  * address size for the VM. Bits[7-0] are reserved for the guest
  * PA size shift (i.e, log2(PA_Size)). For backward compatibility,
  * value 0 implies the default IPA size, 40bits.
+ *
+ * Bits[30-31] are reserved for the VM type
  */
 #define KVM_VM_TYPE_ARM_IPA_SIZE_MASK	0xffULL
 #define KVM_VM_TYPE_ARM_IPA_SIZE(x)		\
 	((x) & KVM_VM_TYPE_ARM_IPA_SIZE_MASK)
+
+#define KVM_VM_TYPE_ARM_NORMAL		0
+#define KVM_VM_TYPE_ARM_REALM		(1UL << 30)
+#define KVM_VM_TYPE_ARM_PROTECTED	(1UL << 31)
+#define KVM_VM_TYPE_ARM_MASK		(KVM_VM_TYPE_ARM_IPA_SIZE_MASK | \
+					 KVM_VM_TYPE_ARM_PROTECTED | \
+					 KVM_VM_TYPE_ARM_REALM)
+
 /*
  * ioctls for /dev/kvm fds:
  */
@@ -701,6 +711,8 @@ struct kvm_enable_cap {
 #define KVM_GET_SUPPORTED_CPUID   _IOWR(KVMIO, 0x05, struct kvm_cpuid2)
 #define KVM_GET_EMULATED_CPUID	  _IOWR(KVMIO, 0x09, struct kvm_cpuid2)
 #define KVM_GET_MSR_FEATURE_INDEX_LIST    _IOWR(KVMIO, 0x0a, struct kvm_msr_list)
+
+#define KVM_ARM_RMI_POPULATE	  _IOWR(KVMIO, 0xd7, struct kvm_arm_rmi_populate)
 
 /*
  * Extension capability list.
@@ -966,6 +978,10 @@ struct kvm_enable_cap {
 #define KVM_CAP_GUEST_MEMFD_FLAGS 244
 #define KVM_CAP_ARM_SEA_TO_USER 245
 #define KVM_CAP_S390_USER_OPEREXEC 246
+#define KVM_CAP_S390_KEYOP 247
+#define KVM_CAP_S390_VSIE_ESAMODE 248
+#define KVM_CAP_S390_HPAGE_2G 249
+#define KVM_CAP_ARM_RMI 250
 
 struct kvm_irq_routing_irqchip {
 	__u32 irqchip;

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -678,18 +678,22 @@ struct kvm_enable_cap {
  * PA size shift (i.e, log2(PA_Size)). For backward compatibility,
  * value 0 implies the default IPA size, 40bits.
  *
- * Bits[30-31] are reserved for the VM type
+ * Bits[11-8] are reserved for the VM type, bit[31] for protected VMs.
  */
 #define KVM_VM_TYPE_ARM_IPA_SIZE_MASK	0xffULL
 #define KVM_VM_TYPE_ARM_IPA_SIZE(x)		\
 	((x) & KVM_VM_TYPE_ARM_IPA_SIZE_MASK)
 
-#define KVM_VM_TYPE_ARM_NORMAL		0
-#define KVM_VM_TYPE_ARM_REALM		(1UL << 30)
+#define KVM_VM_TYPE_ARM_SHIFT		8
+#define KVM_VM_TYPE_ARM_TYPE_MASK	(0xfULL << KVM_VM_TYPE_ARM_SHIFT)
+#define KVM_VM_TYPE_ARM(_type)		\
+	(((_type) << KVM_VM_TYPE_ARM_SHIFT) & KVM_VM_TYPE_ARM_TYPE_MASK)
+#define KVM_VM_TYPE_ARM_NORMAL		KVM_VM_TYPE_ARM(0)
+#define KVM_VM_TYPE_ARM_REALM		KVM_VM_TYPE_ARM(1)
 #define KVM_VM_TYPE_ARM_PROTECTED	(1UL << 31)
 #define KVM_VM_TYPE_ARM_MASK		(KVM_VM_TYPE_ARM_IPA_SIZE_MASK | \
 					 KVM_VM_TYPE_ARM_PROTECTED | \
-					 KVM_VM_TYPE_ARM_REALM)
+					 KVM_VM_TYPE_ARM_TYPE_MASK)
 
 /*
  * ioctls for /dev/kvm fds:

--- a/linux-headers/linux/tsm.h
+++ b/linux-headers/linux/tsm.h
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note */
+/*
+ * Arm RME device-assignment (RHI DA) definitions.
+ *
+ * WARNING: unlike the rest of linux-headers/, this file is NOT produced by
+ * scripts/update-linux-headers.sh -- it is maintained by hand and mirrors
+ * arch/arm64/include/uapi/asm/rmi-da.h.  Running the update script will not
+ * refresh it.  It lives here only so that the RME device-assignment series
+ * stays self-contained; it must be replaced by a proper header import (and
+ * the SMCCC function IDs moved out of linux-headers/linux/arm-smccc.h) before
+ * this work is posted upstream.
+ */
+#ifndef TSM_H_
+#define TSM_H_
+
+#include <linux/types.h>
+
+#define PCI_TSM_REQ_INFO 0
+#define PCI_TSM_REQ_STATE_CHANGE 1
+
+#define RHI_DA_SUCCESS				0x0
+#define RHI_DA_INCOMPLETE			0x1
+#define RHI_DA_ERROR_DATA_NOT_AVAILABLE		0x2
+#define RHI_DA_ERROR_INVALID_VDEV_ID		0x3
+#define RHI_DA_ERROR_INVALID_OBJECT		0x4
+#define RHI_DA_ERROR_INPUT			0x5
+#define RHI_DA_ERROR_DEVICE			0x6
+#define RHI_DA_ERROR_INVALID_OFFSET		0x7
+#define RHI_DA_ERROR_ACCESS_FAILED		0x8
+#define RHI_DA_ERROR_BUSY			0x9
+
+#define RHI_DA_TDI_CONFIG_UNLOCKED		0x0
+#define RHI_DA_TDI_CONFIG_LOCKED		0x1
+#define RHI_DA_TDI_CONFIG_RUN			0x2
+
+/*
+ * Guest request operation numbers. The values must match the kernel UAPI
+ * in arch/arm64/include/uapi/asm/rmi-da.h; the request payload structs
+ * below mirror that header layout one-for-one.
+ */
+#define __RHI_DA_OBJECT_SIZE			0x1
+#define __RHI_DA_OBJECT_READ			0x2
+#define __RHI_DA_VDEV_UPDATE_INTERFACE_REPORT	0x3
+#define __RHI_DA_VDEV_UPDATE_MEASUREMENTS	0x4
+#define __REC_DA_VDEV_MAP			0x5
+#define __RHI_DA_VDEV_SET_TDI_STATE		0x6
+
+struct arm64_vdev_object_size_guest_req {
+	__u32 req_type;
+	__u32 object_type;
+};
+
+struct arm64_vdev_object_read_guest_req {
+	__u32 req_type;
+	__u32 object_type;
+	__aligned_u64 offset;
+};
+
+struct arm64_vdev_device_measurement_guest_req {
+	__u32 req_type;
+	__u32 reserved;
+	__aligned_u64 flags;
+	__aligned_u64 nonce;
+};
+
+struct arm64_vdev_device_memmap_guest_req {
+	__u32 req_type;
+	__u32 reserved;
+	__aligned_u64 gpa_base;
+	__aligned_u64 gpa_top;
+	__aligned_u64 pa_base;
+};
+
+struct arm64_vdev_set_tdi_state_guest_req {
+	__u32 req_type;
+	__u32 tdi_state;
+};
+
+#endif /* TSM_H_ */

--- a/qapi/qom.json
+++ b/qapi/qom.json
@@ -1249,6 +1249,7 @@
     { 'name': 'pr-manager-helper',
       'if': 'CONFIG_LINUX' },
     'qtest',
+    'rme-guest',
     'rng-builtin',
     'rng-egd',
     { 'name': 'rng-random',

--- a/system/physmem.c
+++ b/system/physmem.c
@@ -3718,6 +3718,25 @@ bool address_space_is_io(AddressSpace *as, hwaddr addr)
     return !(memory_region_is_ram(mr) || memory_region_is_romd(mr));
 }
 
+bool address_space_range_is_ram(AddressSpace *as, hwaddr addr, hwaddr size)
+{
+    MemoryRegion *mr;
+    hwaddr xlat, l;
+
+    RCU_READ_LOCK_GUARD();
+    while (size > 0) {
+        l = size;
+        mr = address_space_translate(as, addr, &xlat, &l, false,
+                                     MEMTXATTRS_UNSPECIFIED);
+        if (!memory_region_is_ram(mr)) {
+            return false;
+        }
+        size -= l;
+        addr += l;
+    }
+    return true;
+}
+
 static hwaddr
 flatview_extend_translation(FlatView *fv, hwaddr addr,
                             hwaddr target_len,

--- a/target/arm/arm-qmp-cmds.c
+++ b/target/arm/arm-qmp-cmds.c
@@ -76,7 +76,7 @@ static const char *cpu_model_advertised_features[] = {
     "sve1408", "sve1536", "sve1664", "sve1792", "sve1920", "sve2048",
     "kvm-no-adjvtime", "kvm-steal-time",
     "pauth", "pauth-impdef", "pauth-qarma3", "pauth-qarma5",
-    "num-breakpoints", "num-watchpoints",
+    "num-breakpoints", "num-watchpoints", "num-pmu-counters",
     NULL
 };
 

--- a/target/arm/arm-qmp-cmds.c
+++ b/target/arm/arm-qmp-cmds.c
@@ -76,6 +76,7 @@ static const char *cpu_model_advertised_features[] = {
     "sve1408", "sve1536", "sve1664", "sve1792", "sve1920", "sve2048",
     "kvm-no-adjvtime", "kvm-steal-time",
     "pauth", "pauth-impdef", "pauth-qarma3", "pauth-qarma5",
+    "num-breakpoints", "num-watchpoints",
     NULL
 };
 

--- a/target/arm/cpu.c
+++ b/target/arm/cpu.c
@@ -850,6 +850,11 @@ static void aarch64_cpu_dump_state(CPUState *cs, FILE *f, int flags)
     const char *ns_status;
     bool sve;
 
+    if (cpu->kvm_rme) {
+        qemu_fprintf(f, "the CPU registers are confidential to the realm\n");
+        return;
+    }
+
     qemu_fprintf(f, " PC=%016" PRIx64 " ", env->pc);
     for (i = 0; i < 32; i++) {
         if (i == 31) {

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -1168,6 +1168,13 @@ struct ArchCPU {
     uint8_t num_bps;
     uint8_t num_wps;
     int8_t num_pmu_ctrs;
+
+    /*
+     * Set once the above have been pushed to KVM.  They can only be applied
+     * before the VM runs, so kvm_arm_reset_vcpu() must not retry on a later
+     * reset.
+     */
+    bool kvm_vcpu_regs_configured;
 };
 
 typedef struct ARMCPUInfo {

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -1163,6 +1163,10 @@ struct ArchCPU {
 
     /* Generic timer counter frequency, in Hz */
     uint64_t gt_cntfrq_hz;
+
+    /* Allows to override the default configuration */
+    uint8_t num_bps;
+    uint8_t num_wps;
 };
 
 typedef struct ARMCPUInfo {

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -1046,6 +1046,9 @@ struct ArchCPU {
     /* KVM steal time */
     OnOffAuto kvm_steal_time;
 
+    /* Realm Management Extension */
+    bool kvm_rme;
+
     /* Uniprocessor system with MP extensions */
     bool mp_is_up;
 

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -1167,6 +1167,7 @@ struct ArchCPU {
     /* Allows to override the default configuration */
     uint8_t num_bps;
     uint8_t num_wps;
+    int8_t num_pmu_ctrs;
 };
 
 typedef struct ARMCPUInfo {
@@ -2100,6 +2101,8 @@ FIELD(GPCCR, APPSAA, 24, 1)
 FIELD(MFAR, FPA, 12, 40)
 FIELD(MFAR, NSE, 62, 1)
 FIELD(MFAR, NS, 63, 1)
+
+FIELD(PMCR, N, 11, 5)
 
 QEMU_BUILD_BUG_ON(ARRAY_SIZE(((ARMCPU *)0)->ccsidr) <= R_V7M_CSSELR_INDEX_MASK);
 

--- a/target/arm/cpu64.c
+++ b/target/arm/cpu64.c
@@ -737,12 +737,53 @@ static void arm_cpu_set_num_bps(Object *obj, Visitor *v, const char *name,
     cpu->num_bps = val;
 }
 
+static void arm_cpu_get_num_pmu_ctrs(Object *obj, Visitor *v, const char *name,
+                                     void *opaque, Error **errp)
+{
+    uint8_t val;
+    ARMCPU *cpu = ARM_CPU(obj);
+
+    if (cpu->num_pmu_ctrs == -1) {
+        val = FIELD_EX64(cpu->isar.reset_pmcr_el0, PMCR, N);
+    } else {
+        val = cpu->num_pmu_ctrs;
+    }
+
+    visit_type_uint8(v, name, &val, errp);
+}
+
+static void arm_cpu_set_num_pmu_ctrs(Object *obj, Visitor *v, const char *name,
+                                     void *opaque, Error **errp)
+{
+    uint8_t val;
+    ARMCPU *cpu = ARM_CPU(obj);
+    uint8_t max_ctrs = FIELD_EX64(cpu->isar.reset_pmcr_el0, PMCR, N);
+
+    if (!visit_type_uint8(v, name, &val, errp)) {
+        return;
+    }
+
+    if (val > max_ctrs) {
+        error_setg(errp, "invalid number of PMU counters");
+        return;
+    }
+
+    cpu->num_pmu_ctrs = val;
+}
+
 static void aarch64_add_kvm_writable_properties(Object *obj)
 {
+    ARMCPU *cpu = ARM_CPU(obj);
+
     object_property_add(obj, "num-breakpoints", "uint8", arm_cpu_get_num_bps,
                         arm_cpu_set_num_bps, NULL, NULL);
     object_property_add(obj, "num-watchpoints", "uint8", arm_cpu_get_num_wps,
                         arm_cpu_set_num_wps, NULL, NULL);
+
+    cpu->num_pmu_ctrs = -1;
+    object_property_add(obj, "num-pmu-counters", "uint8",
+                        arm_cpu_get_num_pmu_ctrs, arm_cpu_set_num_pmu_ctrs,
+                        NULL, NULL);
 }
 #endif /* CONFIG_KVM */
 

--- a/target/arm/cpu64.c
+++ b/target/arm/cpu64.c
@@ -666,6 +666,86 @@ void aarch64_add_pauth_properties(Object *obj)
     }
 }
 
+#if defined(CONFIG_KVM)
+static void arm_cpu_get_num_wps(Object *obj, Visitor *v, const char *name,
+                                void *opaque, Error **errp)
+{
+    uint8_t val;
+    ARMCPU *cpu = ARM_CPU(obj);
+
+    val = cpu->num_wps;
+    if (val == 0) {
+        val = FIELD_EX64(cpu->isar.idregs[ID_AA64DFR0_EL1_IDX],
+                         ID_AA64DFR0, WRPS) + 1;
+    }
+
+    visit_type_uint8(v, name, &val, errp);
+}
+
+static void arm_cpu_set_num_wps(Object *obj, Visitor *v, const char *name,
+                                void *opaque, Error **errp)
+{
+    uint8_t val;
+    ARMCPU *cpu = ARM_CPU(obj);
+    uint8_t max_wps = FIELD_EX64(cpu->isar.idregs[ID_AA64DFR0_EL1_IDX],
+                                 ID_AA64DFR0, WRPS) + 1;
+
+    if (!visit_type_uint8(v, name, &val, errp)) {
+        return;
+    }
+
+    if (val < 2 || val > max_wps) {
+        error_setg(errp, "invalid number of watchpoints");
+        return;
+   }
+
+    cpu->num_wps = val;
+}
+
+static void arm_cpu_get_num_bps(Object *obj, Visitor *v, const char *name,
+                                void *opaque, Error **errp)
+{
+    uint8_t val;
+    ARMCPU *cpu = ARM_CPU(obj);
+
+    val = cpu->num_bps;
+    if (val == 0) {
+        val = FIELD_EX64(cpu->isar.idregs[ID_AA64DFR0_EL1_IDX],
+                         ID_AA64DFR0, BRPS) + 1;
+    }
+
+    visit_type_uint8(v, name, &val, errp);
+}
+
+static void arm_cpu_set_num_bps(Object *obj, Visitor *v, const char *name,
+                                void *opaque, Error **errp)
+{
+    uint8_t val;
+    ARMCPU *cpu = ARM_CPU(obj);
+    uint8_t max_bps = FIELD_EX64(cpu->isar.idregs[ID_AA64DFR0_EL1_IDX],
+                                 ID_AA64DFR0, BRPS) + 1;
+
+    if (!visit_type_uint8(v, name, &val, errp)) {
+        return;
+    }
+
+    if (val < 2 || val > max_bps) {
+        error_setg(errp, "invalid number of breakpoints");
+       return;
+    }
+
+    cpu->num_bps = val;
+}
+
+static void aarch64_add_kvm_writable_properties(Object *obj)
+{
+    object_property_add(obj, "num-breakpoints", "uint8", arm_cpu_get_num_bps,
+                        arm_cpu_set_num_bps, NULL, NULL);
+    object_property_add(obj, "num-watchpoints", "uint8", arm_cpu_get_num_wps,
+                        arm_cpu_set_num_wps, NULL, NULL);
+}
+#endif /* CONFIG_KVM */
+
 void arm_cpu_lpa2_finalize(ARMCPU *cpu, Error **errp)
 {
     uint64_t t;
@@ -824,6 +904,7 @@ static void aarch64_host_initfn(Object *obj)
 #if defined(CONFIG_KVM)
     kvm_arm_set_cpu_features_from_host(cpu);
     aarch64_add_sve_properties(obj);
+    aarch64_add_kvm_writable_properties(obj);
 #elif defined(CONFIG_HVF)
     hvf_arm_set_cpu_features_from_host(cpu);
 #elif defined(CONFIG_WHPX)

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -1,0 +1,42 @@
+/*
+ * QEMU Arm RME support
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Copyright Linaro 2026
+ */
+
+#include "qemu/osdep.h"
+
+#include "hw/core/boards.h"
+#include "hw/core/cpu.h"
+#include "kvm_arm.h"
+#include "migration/blocker.h"
+#include "qapi/error.h"
+#include "qom/object_interfaces.h"
+#include "system/confidential-guest-support.h"
+#include "system/kvm.h"
+#include "system/runstate.h"
+
+#define TYPE_RME_GUEST "rme-guest"
+OBJECT_DECLARE_SIMPLE_TYPE(RmeGuest, RME_GUEST)
+
+struct RmeGuest {
+    ConfidentialGuestSupport parent_obj;
+};
+
+OBJECT_DEFINE_SIMPLE_TYPE_WITH_INTERFACES(RmeGuest, rme_guest, RME_GUEST,
+                                          CONFIDENTIAL_GUEST_SUPPORT,
+                                          { TYPE_USER_CREATABLE }, { })
+
+static void rme_guest_class_init(ObjectClass *oc, const void *data)
+{
+}
+
+static void rme_guest_init(Object *obj)
+{
+}
+
+static void rme_guest_finalize(Object *obj)
+{
+}

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -43,9 +43,65 @@ OBJECT_DEFINE_SIMPLE_TYPE_WITH_INTERFACES(RmeGuest, rme_guest, RME_GUEST,
 
 static RmeGuest *rme_guest;
 
+static int rme_populate_range(const RmeRamRegion *region, bool measure,
+                              Error **errp)
+{
+    int ret;
+    void *host_ua;
+    hwaddr size = region->size;
+    hwaddr base = region->base;
+    hwaddr start = QEMU_ALIGN_DOWN(base, RME_PAGE_SIZE);
+    hwaddr end = QEMU_ALIGN_UP(base + size, RME_PAGE_SIZE);
+    struct kvm_arm_rmi_populate populate_args;
+
+    host_ua = address_space_map(region->as, base, &size, false,
+                                MEMTXATTRS_UNSPECIFIED);
+
+    populate_args = (struct kvm_arm_rmi_populate) {
+        .base = start,
+        .size = end - start,
+        .source_uaddr = (uintptr_t)host_ua,
+        .flags = measure ? KVM_ARM_RMI_POPULATE_FLAGS_MEASURE : 0,
+    };
+
+    while (populate_args.size > 0) {
+        ret = kvm_vm_ioctl(kvm_state, KVM_ARM_RMI_POPULATE, &populate_args, 0);
+        if (ret) {
+            error_setg_errno(errp, -ret,
+                "failed to populate realm [0x%"HWADDR_PRIx", 0x%"HWADDR_PRIx")",
+                start, end);
+            break;
+        }
+    }
+
+    address_space_unmap(region->as, host_ua, size, false, 0);
+
+    return ret;
+}
+
+static void rme_populate_ram_region(gpointer data, gpointer err)
+{
+    Error **errp = err;
+    const RmeRamRegion *region = data;
+
+    if (*errp) {
+        return;
+    }
+
+    rme_populate_range(region, /* measure */ true, errp);
+}
+
 static void rme_vm_state_change(void *opaque, bool running, RunState state)
 {
+    Error *errp = NULL;
+
     if (!running) {
+        return;
+    }
+
+    g_slist_foreach(rme_guest->ram_regions, rme_populate_ram_region, &errp);
+    g_slist_free_full(g_steal_pointer(&rme_guest->ram_regions), g_free);
+    if (errp) {
         return;
     }
 

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -69,6 +69,15 @@ static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
     return 0;
 }
 
+void kvm_arm_rme_vcpu_init(ARMCPU *cpu)
+{
+    if (!rme_guest) {
+        return;
+    }
+
+    cpu->kvm_rme = true;
+}
+
 static void rme_guest_class_init(ObjectClass *oc, const void *data)
 {
     ConfidentialGuestSupportClass *klass = CONFIDENTIAL_GUEST_SUPPORT_CLASS(oc);

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -10,6 +10,7 @@
 
 #include "hw/core/boards.h"
 #include "hw/core/cpu.h"
+#include "hw/core/loader.h"
 #include "kvm_arm.h"
 #include "migration/blocker.h"
 #include "qapi/error.h"
@@ -22,8 +23,18 @@
 #define TYPE_RME_GUEST "rme-guest"
 OBJECT_DECLARE_SIMPLE_TYPE(RmeGuest, RME_GUEST)
 
+#define RME_PAGE_SIZE qemu_real_host_page_size()
+
+typedef struct {
+    hwaddr base;
+    hwaddr size;
+    AddressSpace *as;
+} RmeRamRegion;
+
 struct RmeGuest {
     ConfidentialGuestSupport parent_obj;
+    Notifier rom_load_notifier;
+    GSList *ram_regions;
 };
 
 OBJECT_DEFINE_SIMPLE_TYPE_WITH_INTERFACES(RmeGuest, rme_guest, RME_GUEST,
@@ -39,6 +50,44 @@ static void rme_vm_state_change(void *opaque, bool running, RunState state)
     }
 
     kvm_mark_guest_state_protected();
+}
+
+static gint rme_compare_ram_regions(gconstpointer a, gconstpointer b)
+{
+    const RmeRamRegion *ra = a;
+    const RmeRamRegion *rb = b;
+
+    g_assert(ra->base != rb->base);
+    return ra->base < rb->base ? -1 : 1;
+}
+
+static void rme_rom_load_notify(Notifier *notifier, void *data)
+{
+    RmeRamRegion *region;
+    RomLoaderNotifyData *rom = data;
+
+    if (rom->addr == -1) {
+        /*
+         * These blobs (ACPI tables) are not loaded into guest RAM at reset.
+         * Instead the firmware will load them via fw_cfg and measure them
+         * itself.
+         */
+        return;
+    }
+
+    region = g_new0(RmeRamRegion, 1);
+    region->base = rom->addr;
+    region->size = rom->len;
+    region->as = rom->as;
+
+    /*
+     * The Realm Initial Measurement (RIM) depends on the order in which we
+     * initialize and populate the RAM regions. To help a verifier
+     * independently calculate the RIM, sort regions by GPA.
+     */
+    rme_guest->ram_regions = g_slist_insert_sorted(rme_guest->ram_regions,
+                                                   region,
+                                                   rme_compare_ram_regions);
 }
 
 static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
@@ -57,6 +106,9 @@ static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
 
     error_setg(&rme_mig_blocker, "RME: migration is not implemented");
     migrate_add_blocker(&rme_mig_blocker, &error_fatal);
+
+    rme_guest->rom_load_notifier.notify = rme_rom_load_notify;
+    rom_add_load_notifier(&rme_guest->rom_load_notifier);
 
     /*
      * The realm activation is done last, when the VM starts, after all images

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -11,10 +11,12 @@
 #include "hw/core/boards.h"
 #include "hw/core/cpu.h"
 #include "hw/core/loader.h"
+#include "hw/pci/pci.h"
 #include "kvm_arm.h"
 #include "migration/blocker.h"
 #include "qapi/error.h"
 #include "qemu/error-report.h"
+#include "qemu/units.h"
 #include "qom/object_interfaces.h"
 #include "system/confidential-guest-support.h"
 #include "system/kvm.h"
@@ -24,6 +26,23 @@
 OBJECT_DECLARE_SIMPLE_TYPE(RmeGuest, RME_GUEST)
 
 #define RME_PAGE_SIZE qemu_real_host_page_size()
+
+/*
+ * Realms have a split guest-physical address space: the bottom half is private
+ * to the realm, and the top half is shared with the host. Within QEMU, we use a
+ * merged view of both halves. Most of RAM is private to the guest and not
+ * accessible to us, but the guest shares some pages with us.
+ *
+ * RealmDmaRegion performs remapping of top-half accesses to system memory.
+ */
+struct RealmDmaRegion {
+    IOMMUMemoryRegion parent_obj;
+};
+
+#define TYPE_REALM_DMA_REGION "realm-dma-region"
+OBJECT_DECLARE_SIMPLE_TYPE(RealmDmaRegion, REALM_DMA_REGION)
+OBJECT_DEFINE_SIMPLE_TYPE(RealmDmaRegion, realm_dma_region,
+                          REALM_DMA_REGION, IOMMU_MEMORY_REGION);
 
 typedef struct {
     hwaddr base;
@@ -35,6 +54,10 @@ struct RmeGuest {
     ConfidentialGuestSupport parent_obj;
     Notifier rom_load_notifier;
     GSList *ram_regions;
+    uint8_t ipa_bits;
+
+    RealmDmaRegion *dma_region;
+    AddressSpace dma_as;
 };
 
 OBJECT_DEFINE_SIMPLE_TYPE_WITH_INTERFACES(RmeGuest, rme_guest, RME_GUEST,
@@ -204,4 +227,87 @@ static void rme_guest_init(Object *obj)
 
 static void rme_guest_finalize(Object *obj)
 {
+}
+
+static AddressSpace *rme_dma_get_address_space(PCIBus *bus, void *opaque,
+                                               int devfn)
+{
+    return &rme_guest->dma_as;
+}
+
+static const PCIIOMMUOps rme_dma_ops = {
+    .get_address_space = rme_dma_get_address_space,
+};
+
+void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus)
+{
+    RealmDmaRegion *dma_region;
+    const unsigned int ipa_bits = 64 - clz64(highest_gpa) + 1;
+
+    if (!rme_guest) {
+        return;
+    }
+
+    assert(ipa_bits < 64);
+
+    /*
+     * Setup a DMA translation from the shared top half of the guest-physical
+     * address space to our merged view of RAM.
+     */
+    dma_region = g_new0(RealmDmaRegion, 1);
+
+    memory_region_init_iommu(dma_region, sizeof(*dma_region),
+                             TYPE_REALM_DMA_REGION, OBJECT(rme_guest),
+                             "realm-dma-region", 1ULL << ipa_bits);
+    address_space_init(&rme_guest->dma_as, MEMORY_REGION(dma_region),
+                       TYPE_REALM_DMA_REGION);
+    rme_guest->dma_region = dma_region;
+    rme_guest->ipa_bits = ipa_bits;
+
+    pci_setup_iommu(pci_bus, &rme_dma_ops, NULL);
+}
+
+static void realm_dma_region_init(Object *obj)
+{
+}
+
+static IOMMUTLBEntry realm_dma_region_translate(IOMMUMemoryRegion *mr,
+                                                hwaddr addr,
+                                                IOMMUAccessFlags flag,
+                                                int iommu_idx)
+{
+    const hwaddr address_mask = MAKE_64BIT_MASK(0, rme_guest->ipa_bits - 1);
+    IOMMUTLBEntry entry = {
+        .target_as = &address_space_memory,
+        .iova = addr,
+        .translated_addr = addr & address_mask,
+        /*
+         * Somewhat arbitrary granule for users that need one, such as
+         * address_space_get_iotlb_entry(). Should be relatively large to
+         * avoid frequent TLB misses. It can't be larger than memory region
+         * alignment (eg. address_mask) because that would mask the whole
+         * address, preventing vhost from finding the correct memory region.
+         */
+        .addr_mask = 4 * KiB - 1,
+        .perm = IOMMU_RW,
+    };
+
+    return entry;
+}
+
+static void realm_dma_region_replay(IOMMUMemoryRegion *mr, IOMMUNotifier *n)
+{
+    /* Nothing is shared at boot */
+}
+
+static void realm_dma_region_finalize(Object *obj)
+{
+}
+
+static void realm_dma_region_class_init(ObjectClass *oc, const void *data)
+{
+    IOMMUMemoryRegionClass *imrc = IOMMU_MEMORY_REGION_CLASS(oc);
+
+    imrc->translate = realm_dma_region_translate;
+    imrc->replay = realm_dma_region_replay;
 }

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -13,6 +13,7 @@
 #include "kvm_arm.h"
 #include "migration/blocker.h"
 #include "qapi/error.h"
+#include "qemu/error-report.h"
 #include "qom/object_interfaces.h"
 #include "system/confidential-guest-support.h"
 #include "system/kvm.h"
@@ -29,12 +30,59 @@ OBJECT_DEFINE_SIMPLE_TYPE_WITH_INTERFACES(RmeGuest, rme_guest, RME_GUEST,
                                           CONFIDENTIAL_GUEST_SUPPORT,
                                           { TYPE_USER_CREATABLE }, { })
 
+static RmeGuest *rme_guest;
+
+static void rme_vm_state_change(void *opaque, bool running, RunState state)
+{
+    if (!running) {
+        return;
+    }
+
+    kvm_mark_guest_state_protected();
+}
+
+static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
+{
+    KVMState *s = KVM_STATE(current_accel());
+    static Error *rme_mig_blocker;
+
+    if (!rme_guest) {
+        return 0;
+    }
+
+    if (!kvm_vm_check_extension(s, KVM_CAP_ARM_RMI)) {
+        error_setg(errp, "VM doesn't support Realms");
+        return -ENODEV;
+    }
+
+    error_setg(&rme_mig_blocker, "RME: migration is not implemented");
+    migrate_add_blocker(&rme_mig_blocker, &error_fatal);
+
+    /*
+     * The realm activation is done last, when the VM starts, after all images
+     * have been loaded and all vcpus finalized.
+     */
+    qemu_add_vm_change_state_handler(rme_vm_state_change, NULL);
+
+    cgs->require_guest_memfd = true;
+    cgs->ready = true;
+    return 0;
+}
+
 static void rme_guest_class_init(ObjectClass *oc, const void *data)
 {
+    ConfidentialGuestSupportClass *klass = CONFIDENTIAL_GUEST_SUPPORT_CLASS(oc);
+
+    klass->kvm_init = kvm_arm_rme_init;
 }
 
 static void rme_guest_init(Object *obj)
 {
+    if (rme_guest) {
+        error_report("a single instance of RmeGuest is supported");
+        exit(1);
+    }
+    rme_guest = RME_GUEST(obj);
 }
 
 static void rme_guest_finalize(Object *obj)

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -432,6 +432,13 @@ void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus)
     pci_setup_iommu(pci_bus, &rme_dma_ops, guest);
 }
 
+AddressSpace *kvm_arm_rme_get_dma_as(void)
+{
+    RmeGuest *guest = rme_get_machine_guest();
+
+    return guest && guest->dma_region ? &guest->dma_as : NULL;
+}
+
 static void realm_dma_region_init(Object *obj)
 {
 }

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -303,7 +303,12 @@ static void rme_rom_load_notify(Notifier *notifier, void *data)
  * hosts built from the same snapshot. NVIDIA kernels export the live value
  * as a module parameter; prefer it and fall back to the compile-time
  * constant.
+ *
+ * FIXME: this is a downstream-only workaround and must be dropped before the
+ * series is posted upstream, where KVM_CAP_ARM_RMI will have a fixed value.
  */
+#define KVM_CAP_ARM_RMI_MAX 4095
+
 static unsigned int kvm_arm_rme_get_cap(void)
 {
     static unsigned int rme_cap;
@@ -317,8 +322,17 @@ static unsigned int kvm_arm_rme_get_cap(void)
 
         f = fopen(KVM_CAP_ARM_RMI_SYSFS_PATH, "r");
         if (f) {
-            if (fscanf(f, "%d", &cap) == 1 && cap > 0) {
+            /*
+             * Bound the value: a garbage module parameter would otherwise
+             * turn into a wild KVM_CHECK_EXTENSION argument.
+             */
+            if (fscanf(f, "%d", &cap) == 1 &&
+                cap > 0 && cap <= KVM_CAP_ARM_RMI_MAX) {
                 rme_cap = cap;
+            } else {
+                warn_report("ignoring out-of-range %s, falling back to "
+                            "KVM_CAP_ARM_RMI=%d",
+                            KVM_CAP_ARM_RMI_SYSFS_PATH, KVM_CAP_ARM_RMI);
             }
             fclose(f);
         }

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -53,7 +53,9 @@ typedef struct {
 struct RmeGuest {
     ConfidentialGuestSupport parent_obj;
     Notifier rom_load_notifier;
+    VMChangeStateEntry *vm_state_handler;
     GSList *ram_regions;
+    bool rom_load_notifier_registered;
     bool activated;
     uint8_t ipa_bits;
 
@@ -65,7 +67,17 @@ OBJECT_DEFINE_SIMPLE_TYPE_WITH_INTERFACES(RmeGuest, rme_guest, RME_GUEST,
                                           CONFIDENTIAL_GUEST_SUPPORT,
                                           { TYPE_USER_CREATABLE }, { })
 
-static RmeGuest *rme_guest;
+static RmeGuest *rme_get_machine_guest(void)
+{
+    MachineState *machine = MACHINE(qdev_get_machine());
+
+    if (!machine->cgs ||
+        !object_dynamic_cast(OBJECT(machine->cgs), TYPE_RME_GUEST)) {
+        return NULL;
+    }
+
+    return RME_GUEST(machine->cgs);
+}
 
 static int rme_populate_range(const RmeRamRegion *region, bool measure,
                               Error **errp)
@@ -318,12 +330,9 @@ static unsigned int kvm_arm_rme_get_cap(void)
 
 static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
 {
+    RmeGuest *guest = RME_GUEST(cgs);
     KVMState *s = KVM_STATE(current_accel());
     static Error *rme_mig_blocker;
-
-    if (!rme_guest) {
-        return 0;
-    }
 
     if (!kvm_vm_check_extension(s, kvm_arm_rme_get_cap())) {
         error_setg(errp, "VM doesn't support Realms");
@@ -333,14 +342,16 @@ static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
     error_setg(&rme_mig_blocker, "RME: migration is not implemented");
     migrate_add_blocker(&rme_mig_blocker, &error_fatal);
 
-    rme_guest->rom_load_notifier.notify = rme_rom_load_notify;
-    rom_add_load_notifier(&rme_guest->rom_load_notifier);
+    guest->rom_load_notifier.notify = rme_rom_load_notify;
+    rom_add_load_notifier(&guest->rom_load_notifier);
+    guest->rom_load_notifier_registered = true;
 
     /*
      * The realm activation is done last, when the VM starts, after all images
      * have been loaded and all vcpus finalized.
      */
-    qemu_add_vm_change_state_handler(rme_vm_state_change, rme_guest);
+    guest->vm_state_handler =
+        qemu_add_vm_change_state_handler(rme_vm_state_change, guest);
 
     cgs->require_guest_memfd = true;
     cgs->ready = true;
@@ -349,7 +360,7 @@ static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
 
 void kvm_arm_rme_vcpu_init(ARMCPU *cpu)
 {
-    if (!rme_guest) {
+    if (!rme_get_machine_guest()) {
         return;
     }
 
@@ -365,21 +376,27 @@ static void rme_guest_class_init(ObjectClass *oc, const void *data)
 
 static void rme_guest_init(Object *obj)
 {
-    if (rme_guest) {
-        error_report("a single instance of RmeGuest is supported");
-        exit(1);
-    }
-    rme_guest = RME_GUEST(obj);
 }
 
 static void rme_guest_finalize(Object *obj)
 {
+    RmeGuest *guest = RME_GUEST(obj);
+
+    if (guest->rom_load_notifier_registered) {
+        notifier_remove(&guest->rom_load_notifier);
+    }
+    if (guest->vm_state_handler) {
+        qemu_del_vm_change_state_handler(guest->vm_state_handler);
+    }
+    g_slist_free_full(guest->ram_regions, g_free);
 }
 
 static AddressSpace *rme_dma_get_address_space(PCIBus *bus, void *opaque,
                                                int devfn)
 {
-    return &rme_guest->dma_as;
+    RmeGuest *guest = opaque;
+
+    return &guest->dma_as;
 }
 
 static const PCIIOMMUOps rme_dma_ops = {
@@ -388,10 +405,11 @@ static const PCIIOMMUOps rme_dma_ops = {
 
 void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus)
 {
+    RmeGuest *guest = rme_get_machine_guest();
     RealmDmaRegion *dma_region;
     const unsigned int ipa_bits = 64 - clz64(highest_gpa) + 1;
 
-    if (!rme_guest) {
+    if (!guest) {
         return;
     }
 
@@ -404,14 +422,14 @@ void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus)
     dma_region = g_new0(RealmDmaRegion, 1);
 
     memory_region_init_iommu(dma_region, sizeof(*dma_region),
-                             TYPE_REALM_DMA_REGION, OBJECT(rme_guest),
+                             TYPE_REALM_DMA_REGION, OBJECT(guest),
                              "realm-dma-region", 1ULL << ipa_bits);
-    address_space_init(&rme_guest->dma_as, MEMORY_REGION(dma_region),
+    address_space_init(&guest->dma_as, MEMORY_REGION(dma_region),
                        TYPE_REALM_DMA_REGION);
-    rme_guest->dma_region = dma_region;
-    rme_guest->ipa_bits = ipa_bits;
+    guest->dma_region = dma_region;
+    guest->ipa_bits = ipa_bits;
 
-    pci_setup_iommu(pci_bus, &rme_dma_ops, NULL);
+    pci_setup_iommu(pci_bus, &rme_dma_ops, guest);
 }
 
 static void realm_dma_region_init(Object *obj)

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -423,7 +423,9 @@ static IOMMUTLBEntry realm_dma_region_translate(IOMMUMemoryRegion *mr,
                                                 IOMMUAccessFlags flag,
                                                 int iommu_idx)
 {
-    const hwaddr address_mask = MAKE_64BIT_MASK(0, rme_guest->ipa_bits - 1);
+    RmeGuest *guest = RME_GUEST(memory_region_owner(MEMORY_REGION(mr)));
+    const hwaddr shared_bit = 1ULL << (guest->ipa_bits - 1);
+    const hwaddr address_mask = shared_bit - 1;
     IOMMUTLBEntry entry = {
         .target_as = &address_space_memory,
         .iova = addr,
@@ -436,7 +438,7 @@ static IOMMUTLBEntry realm_dma_region_translate(IOMMUMemoryRegion *mr,
          * address, preventing vhost from finding the correct memory region.
          */
         .addr_mask = 4 * KiB - 1,
-        .perm = IOMMU_RW,
+        .perm = addr & shared_bit ? IOMMU_RW : IOMMU_NONE,
     };
 
     return entry;

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -54,6 +54,7 @@ struct RmeGuest {
     ConfidentialGuestSupport parent_obj;
     Notifier rom_load_notifier;
     GSList *ram_regions;
+    bool activated;
     uint8_t ipa_bits;
 
     RealmDmaRegion *dma_region;
@@ -69,37 +70,79 @@ static RmeGuest *rme_guest;
 static int rme_populate_range(const RmeRamRegion *region, bool measure,
                               Error **errp)
 {
-    int ret;
-    void *host_ua;
-    hwaddr size = region->size;
+    const hwaddr end = region->base + region->size;
     hwaddr base = region->base;
-    hwaddr start = QEMU_ALIGN_DOWN(base, RME_PAGE_SIZE);
-    hwaddr end = QEMU_ALIGN_UP(base + size, RME_PAGE_SIZE);
-    struct kvm_arm_rmi_populate populate_args;
 
-    host_ua = address_space_map(region->as, base, &size, false,
-                                MEMTXATTRS_UNSPECIFIED);
-
-    populate_args = (struct kvm_arm_rmi_populate) {
-        .base = start,
-        .size = end - start,
-        .source_uaddr = (uintptr_t)host_ua,
-        .flags = measure ? KVM_ARM_RMI_POPULATE_FLAGS_MEASURE : 0,
-    };
-
-    while (populate_args.size > 0) {
-        ret = kvm_vm_ioctl(kvm_state, KVM_ARM_RMI_POPULATE, &populate_args, 0);
-        if (ret) {
-            error_setg_errno(errp, -ret,
-                "failed to populate realm [0x%"HWADDR_PRIx", 0x%"HWADDR_PRIx")",
-                start, end);
-            break;
-        }
+    if (!address_space_range_is_ram(region->as, region->base, region->size)) {
+        error_setg(errp,
+                   "cannot populate non-RAM Realm range "
+                   "[0x%" HWADDR_PRIx ", 0x%" HWADDR_PRIx ")",
+                   region->base, end);
+        return -EINVAL;
     }
 
-    address_space_unmap(region->as, host_ua, size, false, 0);
+    while (base < end) {
+        struct kvm_arm_rmi_populate populate_args;
+        hwaddr mapped_size = end - base;
+        void *host_ua;
+        int ret;
 
-    return ret;
+        host_ua = address_space_map(region->as, base, &mapped_size, false,
+                                    MEMTXATTRS_UNSPECIFIED);
+        if (!host_ua) {
+            error_setg(errp,
+                       "failed to map Realm range "
+                       "[0x%" HWADDR_PRIx ", 0x%" HWADDR_PRIx ")",
+                       base, end);
+            return -ENOMEM;
+        }
+        if (!QEMU_IS_ALIGNED(mapped_size, RME_PAGE_SIZE) ||
+            !QEMU_PTR_IS_ALIGNED(host_ua, RME_PAGE_SIZE)) {
+            error_setg(errp,
+                       "Realm range [0x%" HWADDR_PRIx ", 0x%" HWADDR_PRIx
+                       ") does not have a page-aligned host mapping",
+                       base, base + mapped_size);
+            address_space_unmap(region->as, host_ua, mapped_size, false, 0);
+            return -EINVAL;
+        }
+
+        populate_args = (struct kvm_arm_rmi_populate) {
+            .base = base,
+            .size = mapped_size,
+            .source_uaddr = (uintptr_t)host_ua,
+            .flags = measure ? KVM_ARM_RMI_POPULATE_FLAGS_MEASURE : 0,
+        };
+
+        while (populate_args.size > 0) {
+            hwaddr size = populate_args.size;
+
+            ret = kvm_vm_ioctl(kvm_state, KVM_ARM_RMI_POPULATE,
+                               &populate_args, 0);
+            if (ret) {
+                error_setg_errno(errp, -ret,
+                    "failed to populate Realm "
+                    "[0x%" HWADDR_PRIx ", 0x%" HWADDR_PRIx ")",
+                    region->base, end);
+                address_space_unmap(region->as, host_ua, mapped_size,
+                                    false, 0);
+                return ret;
+            }
+            if (populate_args.size >= size) {
+                error_setg(errp,
+                           "KVM made no progress populating Realm range "
+                           "[0x%" HWADDR_PRIx ", 0x%" HWADDR_PRIx ")",
+                           region->base, end);
+                address_space_unmap(region->as, host_ua, mapped_size,
+                                    false, 0);
+                return -EIO;
+            }
+        }
+
+        address_space_unmap(region->as, host_ua, mapped_size, false, 0);
+        base += mapped_size;
+    }
+
+    return 0;
 }
 
 static void rme_populate_ram_region(gpointer data, gpointer err)
@@ -114,20 +157,75 @@ static void rme_populate_ram_region(gpointer data, gpointer err)
     rme_populate_range(region, /* measure */ true, errp);
 }
 
+static bool rme_coalesce_ram_regions(RmeGuest *guest, Error **errp)
+{
+    GSList *regions = g_steal_pointer(&guest->ram_regions);
+    GSList *result = NULL;
+    GSList **tail = &result;
+    RmeRamRegion *previous = NULL;
+
+    while (regions) {
+        GSList *node = regions;
+        RmeRamRegion *region = node->data;
+        hwaddr region_end = region->base + region->size;
+
+        regions = regions->next;
+        node->next = NULL;
+
+        if (previous && region->base < previous->base + previous->size) {
+            if (region->as != previous->as) {
+                error_setg(errp,
+                           "overlapping Realm ranges use different address "
+                           "spaces at GPA 0x%" HWADDR_PRIx,
+                           region->base);
+                g_slist_free_full(node, g_free);
+                g_slist_free_full(regions, g_free);
+                g_slist_free_full(result, g_free);
+                return false;
+            }
+            previous->size = MAX(previous->base + previous->size,
+                                 region_end) - previous->base;
+            g_free(region);
+            g_slist_free_1(node);
+            continue;
+        }
+
+        if (previous && region->base == previous->base + previous->size &&
+            region->as == previous->as) {
+            previous->size += region->size;
+            g_free(region);
+            g_slist_free_1(node);
+            continue;
+        }
+
+        *tail = node;
+        tail = &node->next;
+        previous = region;
+    }
+
+    guest->ram_regions = result;
+    return true;
+}
+
 static void rme_vm_state_change(void *opaque, bool running, RunState state)
 {
+    RmeGuest *guest = opaque;
     Error *errp = NULL;
 
-    if (!running) {
+    if (!running || guest->activated) {
         return;
     }
 
-    g_slist_foreach(rme_guest->ram_regions, rme_populate_ram_region, &errp);
-    g_slist_free_full(g_steal_pointer(&rme_guest->ram_regions), g_free);
+    if (rme_coalesce_ram_regions(guest, &errp)) {
+        g_slist_foreach(guest->ram_regions, rme_populate_ram_region, &errp);
+    }
+    g_slist_free_full(g_steal_pointer(&guest->ram_regions), g_free);
     if (errp) {
-        return;
+        error_report_err(errp);
+        exit(EXIT_FAILURE);
     }
 
+    guest->activated = true;
     kvm_mark_guest_state_protected();
 }
 
@@ -136,14 +234,18 @@ static gint rme_compare_ram_regions(gconstpointer a, gconstpointer b)
     const RmeRamRegion *ra = a;
     const RmeRamRegion *rb = b;
 
-    g_assert(ra->base != rb->base);
+    if (ra->base == rb->base) {
+        return 0;
+    }
     return ra->base < rb->base ? -1 : 1;
 }
 
 static void rme_rom_load_notify(Notifier *notifier, void *data)
 {
+    RmeGuest *guest = container_of(notifier, RmeGuest, rom_load_notifier);
     RmeRamRegion *region;
     RomLoaderNotifyData *rom = data;
+    hwaddr end;
 
     if (rom->addr == -1) {
         /*
@@ -153,10 +255,21 @@ static void rme_rom_load_notify(Notifier *notifier, void *data)
          */
         return;
     }
+    if (!rom->len) {
+        return;
+    }
+    if (rom->len > HWADDR_MAX - rom->addr ||
+        rom->addr + rom->len > HWADDR_MAX - (RME_PAGE_SIZE - 1)) {
+        error_report("Realm image at 0x%" HWADDR_PRIx " is too large",
+                     rom->addr);
+        exit(EXIT_FAILURE);
+    }
+
+    end = QEMU_ALIGN_UP(rom->addr + rom->len, RME_PAGE_SIZE);
 
     region = g_new0(RmeRamRegion, 1);
-    region->base = rom->addr;
-    region->size = rom->len;
+    region->base = QEMU_ALIGN_DOWN(rom->addr, RME_PAGE_SIZE);
+    region->size = end - region->base;
     region->as = rom->as;
 
     /*
@@ -164,9 +277,8 @@ static void rme_rom_load_notify(Notifier *notifier, void *data)
      * initialize and populate the RAM regions. To help a verifier
      * independently calculate the RIM, sort regions by GPA.
      */
-    rme_guest->ram_regions = g_slist_insert_sorted(rme_guest->ram_regions,
-                                                   region,
-                                                   rme_compare_ram_regions);
+    guest->ram_regions = g_slist_insert_sorted(guest->ram_regions, region,
+                                               rme_compare_ram_regions);
 }
 
 #define KVM_CAP_ARM_RMI_SYSFS_PATH "/sys/module/kvm/parameters/kvm_cap_arm_rmi"
@@ -228,7 +340,7 @@ static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
      * The realm activation is done last, when the VM starts, after all images
      * have been loaded and all vcpus finalized.
      */
-    qemu_add_vm_change_state_handler(rme_vm_state_change, NULL);
+    qemu_add_vm_change_state_handler(rme_vm_state_change, rme_guest);
 
     cgs->require_guest_memfd = true;
     cgs->ready = true;

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -463,7 +463,12 @@ static IOMMUTLBEntry realm_dma_region_translate(IOMMUMemoryRegion *mr,
          * address, preventing vhost from finding the correct memory region.
          */
         .addr_mask = 4 * KiB - 1,
-        .perm = addr & shared_bit ? IOMMU_RW : IOMMU_NONE,
+        /*
+         * Firmware can use the canonical IPA for a page that it has made
+         * shared with the RMM, while Linux DMA addresses carry shared_bit.
+         * Both forms refer to the same host-visible RAM alias.
+         */
+        .perm = IOMMU_RW,
     };
 
     return entry;

--- a/target/arm/kvm-rme.c
+++ b/target/arm/kvm-rme.c
@@ -169,6 +169,41 @@ static void rme_rom_load_notify(Notifier *notifier, void *data)
                                                    rme_compare_ram_regions);
 }
 
+#define KVM_CAP_ARM_RMI_SYSFS_PATH "/sys/module/kvm/parameters/kvm_cap_arm_rmi"
+
+/*
+ * Returns the KVM CCA capability number for the running kernel.
+ *
+ * The capability number is not stable: it shifts whenever other KVM
+ * capabilities land ahead of it, so the value in linux-headers only matches
+ * hosts built from the same snapshot. NVIDIA kernels export the live value
+ * as a module parameter; prefer it and fall back to the compile-time
+ * constant.
+ */
+static unsigned int kvm_arm_rme_get_cap(void)
+{
+    static unsigned int rme_cap;
+    static bool detected;
+
+    if (!detected) {
+        FILE *f;
+        int cap;
+
+        rme_cap = KVM_CAP_ARM_RMI;
+
+        f = fopen(KVM_CAP_ARM_RMI_SYSFS_PATH, "r");
+        if (f) {
+            if (fscanf(f, "%d", &cap) == 1 && cap > 0) {
+                rme_cap = cap;
+            }
+            fclose(f);
+        }
+        detected = true;
+    }
+
+    return rme_cap;
+}
+
 static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
 {
     KVMState *s = KVM_STATE(current_accel());
@@ -178,7 +213,7 @@ static int kvm_arm_rme_init(ConfidentialGuestSupport *cgs, Error **errp)
         return 0;
     }
 
-    if (!kvm_vm_check_extension(s, KVM_CAP_ARM_RMI)) {
+    if (!kvm_vm_check_extension(s, kvm_arm_rme_get_cap())) {
         error_setg(errp, "VM doesn't support Realms");
         return -ENODEV;
     }

--- a/target/arm/kvm-stub.c
+++ b/target/arm/kvm-stub.c
@@ -119,3 +119,8 @@ char *kvm_print_register_name(uint64_t regidx)
 {
     g_assert_not_reached();
 }
+
+void kvm_arm_rme_vcpu_init(ARMCPU *cpu)
+{
+    g_assert_not_reached();
+}

--- a/target/arm/kvm-stub.c
+++ b/target/arm/kvm-stub.c
@@ -42,6 +42,10 @@ bool kvm_arm_el2_supported(void)
     return false;
 }
 
+void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus)
+{
+}
+
 /*
  * These functions should never actually be called without KVM support.
  */

--- a/target/arm/kvm-stub.c
+++ b/target/arm/kvm-stub.c
@@ -46,6 +46,11 @@ void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus)
 {
 }
 
+AddressSpace *kvm_arm_rme_get_dma_as(void)
+{
+    return NULL;
+}
+
 /*
  * These functions should never actually be called without KVM support.
  */

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -2006,6 +2006,8 @@ int kvm_arch_init_vcpu(CPUState *cs)
         cpu->kvm_init_features[0] |= 1 << KVM_ARM_VCPU_HAS_EL2;
     }
 
+    kvm_arm_rme_vcpu_init(cpu);
+
     /* Do KVM_ARM_VCPU_INIT ioctl */
     ret = kvm_arm_vcpu_init(cpu);
     if (ret) {
@@ -2160,6 +2162,29 @@ static int kvm_arch_put_sve(CPUState *cs, uint32_t vq, bool have_ffr)
     return 0;
 }
 
+static int kvm_arm_rme_put_core_regs(CPUState *cs, Error **errp)
+{
+    int i, ret;
+    ARMCPU *cpu = ARM_CPU(cs);
+    CPUARMState *env = &cpu->env;
+
+    /* The RME ABI only allows us to set 8 GPRs and the PC */
+    for (i = 0; i < 8; i++) {
+        ret = kvm_set_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]),
+                              &env->xregs[i]);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    ret = kvm_set_one_reg(cs, AARCH64_CORE_REG(regs.pc), &env->pc);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
 static int kvm_arm_put_core_regs(CPUState *cs, Error **errp)
 {
     uint64_t val;
@@ -2271,7 +2296,11 @@ int kvm_arch_put_registers(CPUState *cs, KvmPutState level, Error **errp)
     int ret;
     ARMCPU *cpu = ARM_CPU(cs);
 
-    ret = kvm_arm_put_core_regs(cs, errp);
+    if (cpu->kvm_rme) {
+        ret = kvm_arm_rme_put_core_regs(cs, errp);
+    } else {
+        ret = kvm_arm_put_core_regs(cs, errp);
+    }
     if (ret) {
         return ret;
     }
@@ -2353,6 +2382,23 @@ static int kvm_arch_get_sve(CPUState *cs, uint32_t vq, bool have_ffr)
             return ret;
         }
         sve_bswap64(r, r, DIV_ROUND_UP(vq * 2, 8));
+    }
+
+    return 0;
+}
+
+static int kvm_arm_rme_get_core_regs(CPUState *cs, Error **errp)
+{
+    int i, ret;
+    ARMCPU *cpu = ARM_CPU(cs);
+    CPUARMState *env = &cpu->env;
+
+    for (i = 0; i < 8; i++) {
+        ret = kvm_get_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]),
+                              &env->xregs[i]);
+        if (ret) {
+            return ret;
+        }
     }
 
     return 0;
@@ -2469,7 +2515,11 @@ int kvm_arch_get_registers(CPUState *cs, Error **errp)
     int ret;
     ARMCPU *cpu = ARM_CPU(cs);
 
-    ret = kvm_arm_get_core_regs(cs, errp);
+    if (cpu->kvm_rme) {
+        ret = kvm_arm_rme_get_core_regs(cs, errp);
+    } else {
+        ret = kvm_arm_get_core_regs(cs, errp);
+    }
     if (ret) {
         return ret;
     }

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -108,7 +108,9 @@ bool kvm_arm_create_scratch_host_vcpu(int *fdarray,
                                       struct kvm_vcpu_init *init)
 {
     int ret = 0, kvmfd = -1, vmfd = -1, cpufd = -1;
+    MachineState *ms = MACHINE(qdev_get_machine());
     int max_vm_pa_size;
+    int vm_type;
 
     kvmfd = qemu_open_old("/dev/kvm", O_RDWR);
     if (kvmfd < 0) {
@@ -118,8 +120,10 @@ bool kvm_arm_create_scratch_host_vcpu(int *fdarray,
     if (max_vm_pa_size < 0) {
         max_vm_pa_size = 0;
     }
+
+    vm_type = (ms->cgs ? KVM_VM_TYPE_ARM_REALM : KVM_VM_TYPE_ARM_NORMAL);
     do {
-        vmfd = ioctl(kvmfd, KVM_CREATE_VM, max_vm_pa_size);
+        vmfd = ioctl(kvmfd, KVM_CREATE_VM, max_vm_pa_size | vm_type);
     } while (vmfd == -1 && errno == EINTR);
     if (vmfd < 0) {
         goto err;

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -2160,7 +2160,7 @@ static int kvm_arch_put_sve(CPUState *cs, uint32_t vq, bool have_ffr)
     return 0;
 }
 
-int kvm_arch_put_registers(CPUState *cs, KvmPutState level, Error **errp)
+static int kvm_arm_put_core_regs(CPUState *cs, Error **errp)
 {
     uint64_t val;
     uint32_t fpr;
@@ -2263,6 +2263,19 @@ int kvm_arch_put_registers(CPUState *cs, KvmPutState level, Error **errp)
         return ret;
     }
 
+    return 0;
+}
+
+int kvm_arch_put_registers(CPUState *cs, KvmPutState level, Error **errp)
+{
+    int ret;
+    ARMCPU *cpu = ARM_CPU(cs);
+
+    ret = kvm_arm_put_core_regs(cs, errp);
+    if (ret) {
+        return ret;
+    }
+
     write_cpustate_to_list(cpu, true);
 
     if (!write_list_to_kvmstate(cpu, level)) {
@@ -2345,7 +2358,7 @@ static int kvm_arch_get_sve(CPUState *cs, uint32_t vq, bool have_ffr)
     return 0;
 }
 
-int kvm_arch_get_registers(CPUState *cs, Error **errp)
+static int kvm_arm_get_core_regs(CPUState *cs, Error **errp)
 {
     uint64_t val;
     unsigned int el;
@@ -2447,6 +2460,19 @@ int kvm_arch_get_registers(CPUState *cs, Error **errp)
         return ret;
     }
     vfp_set_fpcr(env, fpr);
+
+    return 0;
+}
+
+int kvm_arch_get_registers(CPUState *cs, Error **errp)
+{
+    int ret;
+    ARMCPU *cpu = ARM_CPU(cs);
+
+    ret = kvm_arm_get_core_regs(cs, errp);
+    if (ret) {
+        return ret;
+    }
 
     ret = kvm_get_vcpu_events(cpu);
     if (ret) {

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -610,14 +610,14 @@ int kvm_arch_get_default_type(MachineState *ms)
  */
 static struct kvm_smccc_filter rhi_da_smccc_filters[] = {
     {
-        .base        = RHI_DA_VDEV_GET_MEASUREMENTS,
-        .nr_functions    = 0x3,
-        .action        = KVM_SMCCC_FILTER_FWD_TO_USER,
+        .base         = RHI_DA_VDEV_GET_MEASUREMENTS,
+        .nr_functions = 0x3,
+        .action       = KVM_SMCCC_FILTER_FWD_TO_USER,
     },
     {
-        .base        = RHI_DA_FEATURES,
-        .nr_functions    = 0x3,
-        .action        = KVM_SMCCC_FILTER_FWD_TO_USER,
+        .base         = RHI_DA_FEATURES,
+        .nr_functions = 0x3,
+        .action       = KVM_SMCCC_FILTER_FWD_TO_USER,
     },
 };
 
@@ -641,7 +641,7 @@ static void kvm_arm_install_rhi_da_filter(KVMState *s)
     }
 
     for (i = 0; i < ARRAY_SIZE(rhi_da_smccc_filters); i++) {
-        attr.addr = (uint64_t)&rhi_da_smccc_filters[i];
+        attr.addr = (uintptr_t)&rhi_da_smccc_filters[i];
 
         if (kvm_vm_ioctl(s, KVM_SET_DEVICE_ATTR, &attr)) {
             warn_report("Failed to install RHI device-assignment "
@@ -1100,9 +1100,27 @@ static bool kvm_arm_configure_pmcr(ARMCPU *cpu)
     return true;
 }
 
+/*
+ * Apply the user-requested overrides for the number of breakpoints,
+ * watchpoints and PMU counters.
+ *
+ * Both of these are one-shot in KVM: writes to ID registers and
+ * KVM_ARM_VCPU_PMU_V3_SET_NR_COUNTERS are rejected with -EBUSY once the VM
+ * has run.  kvm_arm_reset_vcpu() runs on every guest reset, so only do this
+ * on the first one; otherwise a plain "system_reset" would fail here.
+ */
 static bool kvm_arm_configure_vcpu_regs(ARMCPU *cpu)
 {
-    return kvm_arm_configure_aa64dfr0(cpu) && kvm_arm_configure_pmcr(cpu);
+    if (cpu->kvm_vcpu_regs_configured) {
+        return true;
+    }
+
+    if (!kvm_arm_configure_aa64dfr0(cpu) || !kvm_arm_configure_pmcr(cpu)) {
+        return false;
+    }
+
+    cpu->kvm_vcpu_regs_configured = true;
+    return true;
 }
 
 /**
@@ -1326,7 +1344,13 @@ void kvm_arm_reset_vcpu(ARMCPU *cpu)
      * Before loading the KVM values into CPUState, update the KVM configuration
      */
     if (!kvm_arm_configure_vcpu_regs(cpu)) {
-        abort();
+        /*
+         * The individual helpers have already reported what went wrong.  This
+         * is a configuration failure rather than an internal inconsistency,
+         * so exit cleanly instead of dumping core.
+         */
+        error_report("Failed to apply the requested vCPU configuration");
+        exit(1);
     }
 
     if (!write_kvmstate_to_list(cpu)) {
@@ -1764,12 +1788,103 @@ static bool kvm_arm_handle_debug(ARMCPU *cpu,
     return false;
 }
 
-static int handle_da_vdev_set_tdi_state(ARMCPU *cpu)
+/*
+ * The RHI device-assignment arguments below all come straight from guest
+ * registers, so every one of them has to be validated before use.
+ *
+ * A vDevice is named by a 32-bit Routing ID (segment:BDF).  Reject anything
+ * wider instead of silently truncating, which would otherwise let a guest
+ * address a device it did not name.
+ */
+static bool rhi_da_get_rid(uint64_t reg, uint32_t *rid)
 {
-    CPUARMState *env = &cpu->env;
-    uint64_t guest_rid = env->xregs[1];
-    uint64_t target_state = env->xregs[2];
+    if (reg > UINT32_MAX) {
+        return false;
+    }
+    *rid = reg;
+    return true;
+}
+
+/*
+ * The address space RHI buffer IPAs are resolved in.
+ *
+ * The guest hands over an IPA, and for a buffer the host has to read or write
+ * that IPA carries the "shared" top bit.  The Realm DMA address space strips
+ * that bit and targets the host-visible RAM alias, and passes canonical
+ * addresses through unchanged, so both spellings of the same page work.
+ */
+static AddressSpace *rhi_guest_buffer_as(void)
+{
+    return kvm_arm_rme_get_dma_as() ?: &address_space_memory;
+}
+
+/*
+ * Map a guest buffer passed to an RHI hypercall.
+ *
+ * Refuse anything that is not plain RAM: these buffers are only ever guest
+ * memory, and letting one land on an emulated device would turn a TSM
+ * response into arbitrary MMIO writes.
+ *
+ * Returns the host address of the whole range, or NULL.  On success the
+ * caller must release it with rhi_unmap_guest_buffer() and the same @len.
+ */
+static void *rhi_map_guest_buffer(uint64_t ipa, hwaddr len, bool is_write)
+{
+    AddressSpace *as = rhi_guest_buffer_as();
+    hwaddr mapped = len;
+    void *hva;
+
+    if (!len || !address_space_range_is_ram(as, ipa, len)) {
+        return NULL;
+    }
+
+    hva = address_space_map(as, ipa, &mapped, is_write, MEMTXATTRS_UNSPECIFIED);
+    if (!hva) {
+        return NULL;
+    }
+    if (mapped != len) {
+        address_space_unmap(as, hva, mapped, is_write, 0);
+        return NULL;
+    }
+
+    return hva;
+}
+
+static void rhi_unmap_guest_buffer(void *hva, hwaddr len, bool is_write,
+                                   hwaddr access_len)
+{
+    address_space_unmap(rhi_guest_buffer_as(), hva, len, is_write, access_len);
+}
+
+/* Number of GP registers carrying SMCCC arguments (x0-x5) / results (x0-x3). */
+#define SMCCC_NUM_ARG_REGS 6
+#define SMCCC_NUM_RES_REGS 4
+
+/*
+ * A forwarded SMCCC call.
+ *
+ * @in holds the guest's x0-x5, captured before any result is produced, and
+ * @out holds x0-x3 as they will be written back.  Keeping the two apart
+ * matters: x1-x3 are both argument and result registers, so a handler that
+ * wrote its status into the vCPU's registers directly would clobber arguments
+ * it had not read yet.
+ */
+typedef struct SmcccCall {
+    uint64_t fn;
+    uint64_t in[SMCCC_NUM_ARG_REGS];
+    uint64_t out[SMCCC_NUM_RES_REGS];
+} SmcccCall;
+
+static int handle_da_vdev_set_tdi_state(SmcccCall *call)
+{
+    uint64_t target_state = call->in[2];
     int ret = -EINVAL;
+    uint32_t guest_rid;
+
+    if (!rhi_da_get_rid(call->in[1], &guest_rid)) {
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        return 0;
+    }
 
     if (target_state == RHI_DA_TDI_CONFIG_LOCKED) {
         ret = iommufd_tsm_bind(guest_rid);
@@ -1780,22 +1895,20 @@ static int handle_da_vdev_set_tdi_state(ARMCPU *cpu)
     }
 
     if (!ret) {
-        env->xregs[0] = RHI_DA_SUCCESS;
+        call->out[0] = RHI_DA_SUCCESS;
     } else if (ret == -ENODEV) {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
     } else {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_OBJECT;
+        call->out[0] = RHI_DA_ERROR_INVALID_OBJECT;
     }
 
     /* return to guest. */
     return 0;
 }
 
-static int handle_da_features(ARMCPU *cpu)
+static int handle_da_features(SmcccCall *call)
 {
-    CPUARMState *env = &cpu->env;
-
-    env->xregs[0] = RHI_DA_BASE_FEATURE;
+    call->out[0] = RHI_DA_BASE_FEATURE;
 
     return 0;
 }
@@ -1803,157 +1916,209 @@ static int handle_da_features(ARMCPU *cpu)
 /* Window used to map the guest buffer for RHI object reads/measurements. */
 #define RHI_DA_OBJECT_MAP_SIZE 4096
 
-static int handle_da_object_size(ARMCPU *cpu)
+static int handle_da_object_size(SmcccCall *call)
 {
-    CPUARMState *env = &cpu->env;
-    uint64_t guest_rid = env->xregs[1];
-    uint64_t object_type = env->xregs[2];
-    unsigned int object_size;
+    uint64_t object_type = call->in[2];
+    uint32_t object_size;
+    uint32_t guest_rid;
     int ret;
+
+    if (!rhi_da_get_rid(call->in[1], &guest_rid)) {
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        return 0;
+    }
+    if (object_type > UINT32_MAX) {
+        call->out[0] = RHI_DA_ERROR_INVALID_OBJECT;
+        return 0;
+    }
 
     ret = iommufd_tsm_get_da_object_size(guest_rid, object_type, &object_size);
     if (!ret) {
-        env->xregs[0] = RHI_DA_SUCCESS;
-        env->xregs[1] = object_size;
+        call->out[0] = RHI_DA_SUCCESS;
+        call->out[1] = object_size;
     } else if (ret == -ENODEV) {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
     } else if (ret == -EINVAL) {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_OBJECT;
+        call->out[0] = RHI_DA_ERROR_INVALID_OBJECT;
     } else {
-        env->xregs[0] = RHI_DA_ERROR_DATA_NOT_AVAILABLE;
+        call->out[0] = RHI_DA_ERROR_DATA_NOT_AVAILABLE;
     }
     /* return to guest. */
     return 0;
 }
 
-static int handle_da_object_read(ARMCPU *cpu)
+static int handle_da_object_read(SmcccCall *call)
 {
-    CPUARMState *env = &cpu->env;
-    uint64_t guest_rid = env->xregs[1];
-    uint64_t object_type = env->xregs[2];
-    uint64_t guest_ipa = env->xregs[3];
-    uint64_t max_len = env->xregs[4];
-    uint64_t offset = env->xregs[5];
-    unsigned int resp_len;
-    hwaddr len = RHI_DA_OBJECT_MAP_SIZE;
+    uint64_t object_type = call->in[2];
+    uint64_t guest_ipa = call->in[3];
+    uint64_t max_len = call->in[4];
+    uint64_t offset = call->in[5];
+    uint32_t resp_len;
+    uint32_t guest_rid;
     void *hva;
     int ret;
 
-    hva = cpu_physical_memory_map(guest_ipa, &len, true);
+    if (!rhi_da_get_rid(call->in[1], &guest_rid)) {
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        return 0;
+    }
+    if (object_type > UINT32_MAX) {
+        call->out[0] = RHI_DA_ERROR_INVALID_OBJECT;
+        return 0;
+    }
+
+    /* Do not let the kernel write beyond the guest range mapped below. */
+    if (!max_len || max_len > RHI_DA_OBJECT_MAP_SIZE) {
+        call->out[0] = RHI_DA_ERROR_INPUT;
+        return 0;
+    }
+
+    hva = rhi_map_guest_buffer(guest_ipa, max_len, true);
     if (!hva) {
-        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+        call->out[0] = RHI_DA_ERROR_ACCESS_FAILED;
         return 0;
     }
 
     ret = iommufd_tsm_da_object_read(guest_rid, object_type, offset, hva,
-                                       max_len, &resp_len);
+                                     max_len, &resp_len);
     if (!ret) {
-        env->xregs[0] = RHI_DA_SUCCESS;
-        env->xregs[1] = resp_len;
+        call->out[0] = RHI_DA_SUCCESS;
+        call->out[1] = resp_len;
     } else if (ret == -EFAULT) {
-        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+        call->out[0] = RHI_DA_ERROR_ACCESS_FAILED;
     } else if (ret == -ENODEV) {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
     } else if (ret == -EINVAL) {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_OBJECT;
+        call->out[0] = RHI_DA_ERROR_INVALID_OBJECT;
     } else {
-        env->xregs[0] = RHI_DA_ERROR_DATA_NOT_AVAILABLE;
+        call->out[0] = RHI_DA_ERROR_DATA_NOT_AVAILABLE;
     }
 
     /* Release the mapping; flush back only the bytes written on success. */
-    cpu_physical_memory_unmap(hva, len, true, ret ? 0 : MIN(resp_len, len));
+    rhi_unmap_guest_buffer(hva, max_len, true,
+                           ret ? 0 : MIN(resp_len, max_len));
     return 0;
 }
 
-static int handle_da_get_interface_report(ARMCPU *cpu)
+static int handle_da_get_interface_report(SmcccCall *call)
 {
-    CPUARMState *env = &cpu->env;
-    uint64_t guest_rid = env->xregs[1];
+    uint32_t guest_rid;
     int ret;
+
+    if (!rhi_da_get_rid(call->in[1], &guest_rid)) {
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        return 0;
+    }
 
     ret = iommufd_tsm_da_get_interface_report(guest_rid);
     if (!ret) {
-        env->xregs[0] = RHI_DA_SUCCESS;
+        call->out[0] = RHI_DA_SUCCESS;
     } else if (ret == -ENODEV) {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
     } else {
-        env->xregs[0] = RHI_DA_ERROR_INPUT;
+        call->out[0] = RHI_DA_ERROR_INPUT;
     }
     /* return to guest. */
     return 0;
 }
 
-static int handle_da_get_measurements(ARMCPU *cpu)
+static int handle_da_get_measurements(SmcccCall *call)
 {
-    CPUARMState *env = &cpu->env;
-    uint64_t param;
-    uint64_t guest_rid = env->xregs[1];
     struct rhi_vdev_measurement_params *param_hva;
-    hwaddr len = RHI_DA_OBJECT_MAP_SIZE;
+    const hwaddr len = sizeof(*param_hva);
+    uint32_t guest_rid;
     int ret;
 
-    param = env->xregs[2];
-    param_hva = (struct rhi_vdev_measurement_params *)
-                cpu_physical_memory_map(param, &len, false);
+    if (!rhi_da_get_rid(call->in[1], &guest_rid)) {
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        return 0;
+    }
 
+    param_hva = rhi_map_guest_buffer(call->in[2], len, false);
     if (!param_hva) {
-        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+        call->out[0] = RHI_DA_ERROR_ACCESS_FAILED;
         return 0;
     }
 
     ret = iommufd_tsm_da_get_measurement(guest_rid, param_hva);
     if (!ret) {
-        env->xregs[0] = RHI_DA_SUCCESS;
+        call->out[0] = RHI_DA_SUCCESS;
     } else if (ret == -EFAULT) {
-        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+        call->out[0] = RHI_DA_ERROR_ACCESS_FAILED;
     } else if (ret == -ENODEV) {
-        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+        call->out[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
     } else {
-        env->xregs[0] = RHI_DA_ERROR_INPUT;
+        call->out[0] = RHI_DA_ERROR_INPUT;
     }
 
     /* Read-only mapping of the guest parameter block; nothing to flush back. */
-    cpu_physical_memory_unmap(param_hva, len, false, 0);
+    rhi_unmap_guest_buffer(param_hva, len, false, 0);
     return 0;
 }
 
-static int handle_std_hyp_call(ARMCPU *cpu, struct kvm_run *kvm_run)
+static int handle_std_hyp_call(SmcccCall *call)
 {
-    uint32_t fn = kvm_run->hypercall.nr;
+    /*
+     * SMCCC leaves x1-x3 as result registers.  Start from zero so that a
+     * handler which only produces a status code does not echo the guest's own
+     * arguments back to it.
+     */
+    memset(call->out, 0, sizeof(call->out));
 
-    switch (fn) {
+    switch (call->fn) {
     case RHI_DA_FEATURES:
-        return handle_da_features(cpu);
+        return handle_da_features(call);
     case RHI_DA_OBJECT_SIZE:
-        return handle_da_object_size(cpu);
+        return handle_da_object_size(call);
     case RHI_DA_OBJECT_READ:
-        return handle_da_object_read(cpu);
+        return handle_da_object_read(call);
     case RHI_DA_VDEV_GET_INTERFACE_REPORT:
-        return handle_da_get_interface_report(cpu);
+        return handle_da_get_interface_report(call);
     case RHI_DA_VDEV_GET_MEASUREMENTS:
-        return handle_da_get_measurements(cpu);
+        return handle_da_get_measurements(call);
     case RHI_DA_VDEV_SET_TDI_STATE:
-        return handle_da_vdev_set_tdi_state(cpu);
+        return handle_da_vdev_set_tdi_state(call);
+    default:
+        /*
+         * The SMCCC filter installed by kvm_arm_install_rhi_da_filter()
+         * should keep this unreachable, but never leave the function ID
+         * itself sitting in x0 as if it were a result.
+         */
+        qemu_log_mask(LOG_UNIMP, "%s: unhandled SMCCC function 0x%" PRIx64 "\n",
+                      __func__, call->fn);
+        call->out[0] = (uint64_t)SMCCC_RET_NOT_SUPPORTED;
+        return 0;
     }
-    return 0;
 }
 
-#define REC_ENTER_FLAG_DEV_MEM_RESPONSE (1 << 6)
+/*
+ * RmiRecEnterFlags.dev_mem_response, propagated to REC enter by KVM.  The
+ * encoding follows RmiResponse: 0 == ACCEPT, 1 == REJECT.  So the bit is set
+ * when we could *not* satisfy the mapping request, not when we could.
+ */
+#define REC_ENTER_FLAG_DEV_MEM_RESPONSE_REJECT (1ULL << 6)
 
 static int handle_arm64_tio_exit(struct kvm_run *kvm_run)
 {
     if (kvm_run->cca_exit.nr == RMI_EXIT_VDEV_MAP) {
-        unsigned long gpa_base, gpa_top, pa_base, vdev_id;
-        bool ret;
+        uint64_t gpa_base, gpa_top, pa_base;
+        uint32_t rid;
+        bool accepted;
 
         gpa_base = kvm_run->cca_exit.gpa_base;
         gpa_top = kvm_run->cca_exit.gpa_top;
         pa_base = kvm_run->cca_exit.pa_base;
-        vdev_id = kvm_run->cca_exit.vdev_id;
-        ret = iommufd_tsm_dev_memmap_exit(vdev_id, gpa_base, gpa_top, pa_base);
-        if (!ret) {
-            kvm_run->cca_exit.response = REC_ENTER_FLAG_DEV_MEM_RESPONSE;
+
+        if (kvm_run->cca_exit.vdev_id > UINT32_MAX) {
+            accepted = false;
+        } else {
+            rid = kvm_run->cca_exit.vdev_id;
+            accepted = iommufd_tsm_dev_memmap_exit(rid, gpa_base, gpa_top,
+                                                   pa_base);
         }
+
+        kvm_run->cca_exit.response =
+            accepted ? 0 : REC_ENTER_FLAG_DEV_MEM_RESPONSE_REJECT;
     }
     return 0;
 }
@@ -1961,9 +2126,43 @@ static int handle_arm64_tio_exit(struct kvm_run *kvm_run)
 #define AARCH64_CORE_REG(x)   (KVM_REG_ARM64 | KVM_REG_SIZE_U64 | \
                  KVM_REG_ARM_CORE | KVM_REG_ARM_CORE_REG(x))
 
-/* Number of GP registers carrying SMCCC arguments / results (x0-x5). */
-#define SMCCC_NUM_ARG_REGS 6
-#define SMCCC_NUM_RES_REGS 4
+/*
+ * SMCCC Standard Hypervisor (ARM_SMCCC_OWNER_STANDARD_HYP) call forwarded to
+ * userspace by the filter installed in kvm_arm_install_rhi_da_filter().
+ *
+ * KVM does not sync the GP registers on a hypercall exit, so read the
+ * registers carrying the SMCCC arguments before dispatch and write the
+ * results back afterwards.
+ *
+ * TODO: replace this with first-class SMCCC register handling.
+ */
+static int kvm_arm_handle_hypercall(CPUState *cs, struct kvm_run *run)
+{
+    SmcccCall call = { .fn = run->hypercall.nr };
+    int ret;
+    int i;
+
+    for (i = 0; i < SMCCC_NUM_ARG_REGS; i++) {
+        ret = kvm_get_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]), &call.in[i]);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    ret = handle_std_hyp_call(&call);
+    if (ret) {
+        return ret;
+    }
+
+    for (i = 0; i < SMCCC_NUM_RES_REGS; i++) {
+        ret = kvm_set_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]), &call.out[i]);
+        if (ret) {
+            return ret;
+        }
+    }
+
+    return 0;
+}
 
 int kvm_arch_handle_exit(CPUState *cs, struct kvm_run *run)
 {
@@ -1985,23 +2184,7 @@ int kvm_arch_handle_exit(CPUState *cs, struct kvm_run *run)
         ret = handle_arm64_tio_exit(run);
         break;
     case KVM_EXIT_HYPERCALL:
-        /*
-         * SMCCC Standard Hypervisor (ARM_SMCCC_OWNER_STANDARD_HYP) call.
-         * KVM does not sync the GP registers on a hypercall exit, so read the
-         * registers carrying the SMCCC arguments before dispatch and write
-         * the results back afterwards.
-         *
-         * TODO: replace this with first-class SMCCC register handling.
-         */
-        for (int i = 0; i < SMCCC_NUM_ARG_REGS; i++) {
-            kvm_get_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]),
-                            &cpu->env.xregs[i]);
-        }
-        ret = handle_std_hyp_call(cpu, run);
-        for (int i = 0; i < SMCCC_NUM_RES_REGS; i++) {
-            kvm_set_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]),
-                            &cpu->env.xregs[i]);
-        }
+        ret = kvm_arm_handle_hypercall(cs, run);
         break;
     default:
         qemu_log_mask(LOG_UNIMP, "%s: un-handled exit reason %d\n",

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -43,6 +43,10 @@
 #include "hw/acpi/ghes.h"
 #include "target/arm/gtimer.h"
 #include "migration/blocker.h"
+#include "system/iommufd.h"
+
+#include "linux-headers/linux/arm-smccc.h"
+#include "linux-headers/linux/tsm.h"
 
 const KVMCapabilityInfo kvm_arch_required_capabilities[] = {
     KVM_CAP_INFO(DEVICE_CTRL),
@@ -596,6 +600,56 @@ int kvm_arch_get_default_type(MachineState *ms)
     return fixed_ipa ? 0 : size;
 }
 
+/*
+ * RHI device-assignment hypercalls live in the SMCCC Standard Hypervisor
+ * range and must be forwarded to userspace. Each entry covers a block of
+ * consecutive function IDs (.nr_functions is the count of IDs starting at
+ * .base): RHI_DA_FEATURES/OBJECT_SIZE/OBJECT_READ (0x4B..0x4D) and
+ * RHI_DA_VDEV_GET_MEASUREMENTS/GET_INTERFACE_REPORT/SET_TDI_STATE
+ * (0x52..0x54).
+ */
+static struct kvm_smccc_filter rhi_da_smccc_filters[] = {
+    {
+        .base        = RHI_DA_VDEV_GET_MEASUREMENTS,
+        .nr_functions    = 0x3,
+        .action        = KVM_SMCCC_FILTER_FWD_TO_USER,
+    },
+    {
+        .base        = RHI_DA_FEATURES,
+        .nr_functions    = 0x3,
+        .action        = KVM_SMCCC_FILTER_FWD_TO_USER,
+    },
+};
+
+/*
+ * Forward the RHI device-assignment hypercalls to userspace. Only needed for
+ * realms with assigned devices; the filter is inert for other guests, which
+ * never issue these function IDs.
+ */
+static void kvm_arm_install_rhi_da_filter(KVMState *s)
+{
+    struct kvm_device_attr attr = {
+        .group = KVM_ARM_VM_SMCCC_CTRL,
+        .attr  = KVM_ARM_VM_SMCCC_FILTER,
+    };
+    unsigned int i;
+
+    if (kvm_vm_ioctl(s, KVM_HAS_DEVICE_ATTR, &attr)) {
+        warn_report("KVM SMCCC filter not supported; "
+                    "RME device assignment will not work");
+        return;
+    }
+
+    for (i = 0; i < ARRAY_SIZE(rhi_da_smccc_filters); i++) {
+        attr.addr = (uint64_t)&rhi_da_smccc_filters[i];
+
+        if (kvm_vm_ioctl(s, KVM_SET_DEVICE_ATTR, &attr)) {
+            warn_report("Failed to install RHI device-assignment "
+                        "SMCCC filter");
+        }
+    }
+}
+
 int kvm_arch_init(MachineState *ms, KVMState *s)
 {
     Error *local_err = NULL;
@@ -683,6 +737,10 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
     max_hw_bps = kvm_vm_check_extension(s, KVM_CAP_GUEST_DEBUG_HW_BPS);
     hw_breakpoints = g_array_sized_new(true, true,
                                        sizeof(HWBreakpoint), max_hw_bps);
+
+    if (ms->cgs) {
+        kvm_arm_install_rhi_da_filter(s);
+    }
 
     return ret;
 }
@@ -1706,6 +1764,207 @@ static bool kvm_arm_handle_debug(ARMCPU *cpu,
     return false;
 }
 
+static int handle_da_vdev_set_tdi_state(ARMCPU *cpu)
+{
+    CPUARMState *env = &cpu->env;
+    uint64_t guest_rid = env->xregs[1];
+    uint64_t target_state = env->xregs[2];
+    int ret = -EINVAL;
+
+    if (target_state == RHI_DA_TDI_CONFIG_LOCKED) {
+        ret = iommufd_tsm_bind(guest_rid);
+    } else if (target_state == RHI_DA_TDI_CONFIG_UNLOCKED) {
+        ret = iommufd_tsm_unbind(guest_rid);
+    } else if (target_state == RHI_DA_TDI_CONFIG_RUN) {
+        ret = iommufd_tsm_da_set_tdi_state_run(guest_rid);
+    }
+
+    if (!ret) {
+        env->xregs[0] = RHI_DA_SUCCESS;
+    } else if (ret == -ENODEV) {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+    } else {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_OBJECT;
+    }
+
+    /* return to guest. */
+    return 0;
+}
+
+static int handle_da_features(ARMCPU *cpu)
+{
+    CPUARMState *env = &cpu->env;
+
+    env->xregs[0] = RHI_DA_BASE_FEATURE;
+
+    return 0;
+}
+
+/* Window used to map the guest buffer for RHI object reads/measurements. */
+#define RHI_DA_OBJECT_MAP_SIZE 4096
+
+static int handle_da_object_size(ARMCPU *cpu)
+{
+    CPUARMState *env = &cpu->env;
+    uint64_t guest_rid = env->xregs[1];
+    uint64_t object_type = env->xregs[2];
+    unsigned int object_size;
+    int ret;
+
+    ret = iommufd_tsm_get_da_object_size(guest_rid, object_type, &object_size);
+    if (!ret) {
+        env->xregs[0] = RHI_DA_SUCCESS;
+        env->xregs[1] = object_size;
+    } else if (ret == -ENODEV) {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+    } else if (ret == -EINVAL) {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_OBJECT;
+    } else {
+        env->xregs[0] = RHI_DA_ERROR_DATA_NOT_AVAILABLE;
+    }
+    /* return to guest. */
+    return 0;
+}
+
+static int handle_da_object_read(ARMCPU *cpu)
+{
+    CPUARMState *env = &cpu->env;
+    uint64_t guest_rid = env->xregs[1];
+    uint64_t object_type = env->xregs[2];
+    uint64_t guest_ipa = env->xregs[3];
+    uint64_t max_len = env->xregs[4];
+    uint64_t offset = env->xregs[5];
+    unsigned int resp_len;
+    hwaddr len = RHI_DA_OBJECT_MAP_SIZE;
+    void *hva;
+    int ret;
+
+    hva = cpu_physical_memory_map(guest_ipa, &len, true);
+    if (!hva) {
+        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+        return 0;
+    }
+
+    ret = iommufd_tsm_da_object_read(guest_rid, object_type, offset, hva,
+                                       max_len, &resp_len);
+    if (!ret) {
+        env->xregs[0] = RHI_DA_SUCCESS;
+        env->xregs[1] = resp_len;
+    } else if (ret == -EFAULT) {
+        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+    } else if (ret == -ENODEV) {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+    } else if (ret == -EINVAL) {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_OBJECT;
+    } else {
+        env->xregs[0] = RHI_DA_ERROR_DATA_NOT_AVAILABLE;
+    }
+
+    /* Release the mapping; flush back only the bytes written on success. */
+    cpu_physical_memory_unmap(hva, len, true, ret ? 0 : MIN(resp_len, len));
+    return 0;
+}
+
+static int handle_da_get_interface_report(ARMCPU *cpu)
+{
+    CPUARMState *env = &cpu->env;
+    uint64_t guest_rid = env->xregs[1];
+    int ret;
+
+    ret = iommufd_tsm_da_get_interface_report(guest_rid);
+    if (!ret) {
+        env->xregs[0] = RHI_DA_SUCCESS;
+    } else if (ret == -ENODEV) {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+    } else {
+        env->xregs[0] = RHI_DA_ERROR_INPUT;
+    }
+    /* return to guest. */
+    return 0;
+}
+
+static int handle_da_get_measurements(ARMCPU *cpu)
+{
+    CPUARMState *env = &cpu->env;
+    uint64_t param;
+    uint64_t guest_rid = env->xregs[1];
+    struct rhi_vdev_measurement_params *param_hva;
+    hwaddr len = RHI_DA_OBJECT_MAP_SIZE;
+    int ret;
+
+    param = env->xregs[2];
+    param_hva = (struct rhi_vdev_measurement_params *)
+                cpu_physical_memory_map(param, &len, false);
+
+    if (!param_hva) {
+        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+        return 0;
+    }
+
+    ret = iommufd_tsm_da_get_measurement(guest_rid, param_hva);
+    if (!ret) {
+        env->xregs[0] = RHI_DA_SUCCESS;
+    } else if (ret == -EFAULT) {
+        env->xregs[0] = RHI_DA_ERROR_ACCESS_FAILED;
+    } else if (ret == -ENODEV) {
+        env->xregs[0] = RHI_DA_ERROR_INVALID_VDEV_ID;
+    } else {
+        env->xregs[0] = RHI_DA_ERROR_INPUT;
+    }
+
+    /* Read-only mapping of the guest parameter block; nothing to flush back. */
+    cpu_physical_memory_unmap(param_hva, len, false, 0);
+    return 0;
+}
+
+static int handle_std_hyp_call(ARMCPU *cpu, struct kvm_run *kvm_run)
+{
+    uint32_t fn = kvm_run->hypercall.nr;
+
+    switch (fn) {
+    case RHI_DA_FEATURES:
+        return handle_da_features(cpu);
+    case RHI_DA_OBJECT_SIZE:
+        return handle_da_object_size(cpu);
+    case RHI_DA_OBJECT_READ:
+        return handle_da_object_read(cpu);
+    case RHI_DA_VDEV_GET_INTERFACE_REPORT:
+        return handle_da_get_interface_report(cpu);
+    case RHI_DA_VDEV_GET_MEASUREMENTS:
+        return handle_da_get_measurements(cpu);
+    case RHI_DA_VDEV_SET_TDI_STATE:
+        return handle_da_vdev_set_tdi_state(cpu);
+    }
+    return 0;
+}
+
+#define REC_ENTER_FLAG_DEV_MEM_RESPONSE (1 << 6)
+
+static int handle_arm64_tio_exit(struct kvm_run *kvm_run)
+{
+    if (kvm_run->cca_exit.nr == RMI_EXIT_VDEV_MAP) {
+        unsigned long gpa_base, gpa_top, pa_base, vdev_id;
+        bool ret;
+
+        gpa_base = kvm_run->cca_exit.gpa_base;
+        gpa_top = kvm_run->cca_exit.gpa_top;
+        pa_base = kvm_run->cca_exit.pa_base;
+        vdev_id = kvm_run->cca_exit.vdev_id;
+        ret = iommufd_tsm_dev_memmap_exit(vdev_id, gpa_base, gpa_top, pa_base);
+        if (!ret) {
+            kvm_run->cca_exit.response = REC_ENTER_FLAG_DEV_MEM_RESPONSE;
+        }
+    }
+    return 0;
+}
+
+#define AARCH64_CORE_REG(x)   (KVM_REG_ARM64 | KVM_REG_SIZE_U64 | \
+                 KVM_REG_ARM_CORE | KVM_REG_ARM_CORE_REG(x))
+
+/* Number of GP registers carrying SMCCC arguments / results (x0-x5). */
+#define SMCCC_NUM_ARG_REGS 6
+#define SMCCC_NUM_RES_REGS 4
+
 int kvm_arch_handle_exit(CPUState *cs, struct kvm_run *run)
 {
     ARMCPU *cpu = ARM_CPU(cs);
@@ -1722,11 +1981,34 @@ int kvm_arch_handle_exit(CPUState *cs, struct kvm_run *run)
         ret = kvm_arm_handle_dabt_nisv(cpu, run->arm_nisv.esr_iss,
                                        run->arm_nisv.fault_ipa);
         break;
+    case KVM_EXIT_ARM64_TIO:
+        ret = handle_arm64_tio_exit(run);
+        break;
+    case KVM_EXIT_HYPERCALL:
+        /*
+         * SMCCC Standard Hypervisor (ARM_SMCCC_OWNER_STANDARD_HYP) call.
+         * KVM does not sync the GP registers on a hypercall exit, so read the
+         * registers carrying the SMCCC arguments before dispatch and write
+         * the results back afterwards.
+         *
+         * TODO: replace this with first-class SMCCC register handling.
+         */
+        for (int i = 0; i < SMCCC_NUM_ARG_REGS; i++) {
+            kvm_get_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]),
+                            &cpu->env.xregs[i]);
+        }
+        ret = handle_std_hyp_call(cpu, run);
+        for (int i = 0; i < SMCCC_NUM_RES_REGS; i++) {
+            kvm_set_one_reg(cs, AARCH64_CORE_REG(regs.regs[i]),
+                            &cpu->env.xregs[i]);
+        }
+        break;
     default:
         qemu_log_mask(LOG_UNIMP, "%s: un-handled exit reason %d\n",
                       __func__, run->exit_reason);
         break;
     }
+
     return ret;
 }
 
@@ -2246,9 +2528,6 @@ static void kvm_inject_arm_sea(CPUState *c)
 
     arm_cpu_do_interrupt(c);
 }
-
-#define AARCH64_CORE_REG(x)   (KVM_REG_ARM64 | KVM_REG_SIZE_U64 | \
-                 KVM_REG_ARM_CORE | KVM_REG_ARM_CORE_REG(x))
 
 #define AARCH64_SIMD_CORE_REG(x)   (KVM_REG_ARM64 | KVM_REG_SIZE_U128 | \
                  KVM_REG_ARM_CORE | KVM_REG_ARM_CORE_REG(x))

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -1569,6 +1569,10 @@ static void kvm_arm_vm_state_change(void *opaque, bool running, RunState state)
 {
     ARMCPU *cpu = opaque;
 
+    if (kvm_guest_state_protected()) {
+        return;
+    }
+
     if (running) {
         if (cpu->kvm_adjvtime) {
             kvm_arm_put_virtual_time(cpu);

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -995,6 +995,11 @@ static bool kvm_arm_configure_pmcr(ARMCPU *cpu)
         return true;
     }
 
+    /* An explicit zero is already satisfied when this vCPU has no PMU. */
+    if (!cpu->has_pmu && cpu->num_pmu_ctrs == 0) {
+        return true;
+    }
+
     /*
      * Realms restrict which registers userspace may write. Prefer the PMU
      * device attribute, which configures the VM-wide PMCR_EL0.N value without

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -2149,7 +2149,14 @@ static int kvm_arm_handle_hypercall(CPUState *cs, struct kvm_run *run)
         }
     }
 
+    /*
+     * RHI dispatch looks up and operates on VFIO devices.  The global VFIO
+     * device list and device lifetime are protected by the BQL, which is not
+     * held while kvm_cpu_exec() handles architecture-specific exits.
+     */
+    bql_lock();
     ret = handle_std_hyp_call(&call);
+    bql_unlock();
     if (ret) {
         return ret;
     }
@@ -2181,7 +2188,13 @@ int kvm_arch_handle_exit(CPUState *cs, struct kvm_run *run)
                                        run->arm_nisv.fault_ipa);
         break;
     case KVM_EXIT_ARM64_TIO:
+        /*
+         * See the VFIO device-lifetime comment in
+         * kvm_arm_handle_hypercall().
+         */
+        bql_lock();
         ret = handle_arm64_tio_exit(run);
+        bql_unlock();
         break;
     case KVM_EXIT_HYPERCALL:
         ret = kvm_arm_handle_hypercall(cs, run);

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -222,8 +222,8 @@ static int read_sys_reg64(int fd, uint64_t *pret, uint64_t id)
 
 static bool kvm_arm_pauth_supported(void)
 {
-    return (kvm_check_extension(kvm_state, KVM_CAP_ARM_PTRAUTH_ADDRESS) &&
-            kvm_check_extension(kvm_state, KVM_CAP_ARM_PTRAUTH_GENERIC));
+    return (kvm_vm_check_extension(kvm_state, KVM_CAP_ARM_PTRAUTH_ADDRESS) &&
+            kvm_vm_check_extension(kvm_state, KVM_CAP_ARM_PTRAUTH_GENERIC));
 }
 
 
@@ -302,7 +302,7 @@ static bool kvm_arm_get_host_cpu_features(ARMHostCPUFeatures *ahcf)
      * Ask for SVE if supported, so that we can query ID_AA64ZFR0,
      * which is otherwise RAZ.
      */
-    sve_supported = kvm_check_extension(kvm_state, KVM_CAP_ARM_SVE);
+    sve_supported = kvm_vm_check_extension(kvm_state, KVM_CAP_ARM_SVE);
     if (sve_supported) {
         init.features[0] |= 1 << KVM_ARM_VCPU_SVE;
     }
@@ -2069,17 +2069,17 @@ void kvm_arm_steal_time_finalize(ARMCPU *cpu, Error **errp)
 
 bool kvm_arm_aarch32_supported(void)
 {
-    return kvm_check_extension(kvm_state, KVM_CAP_ARM_EL1_32BIT);
+    return kvm_vm_check_extension(kvm_state, KVM_CAP_ARM_EL1_32BIT);
 }
 
 bool kvm_arm_el2_supported(void)
 {
-    return kvm_check_extension(kvm_state, KVM_CAP_ARM_EL2);
+    return kvm_vm_check_extension(kvm_state, KVM_CAP_ARM_EL2);
 }
 
 bool kvm_arm_mte_supported(void)
 {
-    return kvm_check_extension(kvm_state, KVM_CAP_ARM_MTE);
+    return kvm_vm_check_extension(kvm_state, KVM_CAP_ARM_MTE);
 }
 
 QEMU_BUILD_BUG_ON(KVM_ARM64_SVE_VQ_MIN != 1);

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -2100,26 +2100,30 @@ static int handle_std_hyp_call(SmcccCall *call)
 
 static int handle_arm64_tio_exit(struct kvm_run *kvm_run)
 {
-    if (kvm_run->cca_exit.nr == RMI_EXIT_VDEV_MAP) {
-        uint64_t gpa_base, gpa_top, pa_base;
-        uint32_t rid;
-        bool accepted;
+    uint64_t gpa_base, gpa_top, pa_base;
+    uint32_t rid;
+    bool accepted;
 
-        gpa_base = kvm_run->cca_exit.gpa_base;
-        gpa_top = kvm_run->cca_exit.gpa_top;
-        pa_base = kvm_run->cca_exit.pa_base;
-
-        if (kvm_run->cca_exit.vdev_id > UINT32_MAX) {
-            accepted = false;
-        } else {
-            rid = kvm_run->cca_exit.vdev_id;
-            accepted = iommufd_tsm_dev_memmap_exit(rid, gpa_base, gpa_top,
-                                                   pa_base);
-        }
-
-        kvm_run->cca_exit.response =
-            accepted ? 0 : REC_ENTER_FLAG_DEV_MEM_RESPONSE_REJECT;
+    if (kvm_run->cca_exit.nr != RMI_EXIT_VDEV_MAP) {
+        error_report("unsupported KVM_EXIT_ARM64_TIO operation 0x%" PRIx64,
+                     (uint64_t)kvm_run->cca_exit.nr);
+        return -EINVAL;
     }
+
+    gpa_base = kvm_run->cca_exit.gpa_base;
+    gpa_top = kvm_run->cca_exit.gpa_top;
+    pa_base = kvm_run->cca_exit.pa_base;
+
+    if (kvm_run->cca_exit.vdev_id > UINT32_MAX) {
+        accepted = false;
+    } else {
+        rid = kvm_run->cca_exit.vdev_id;
+        accepted = iommufd_tsm_dev_memmap_exit(rid, gpa_base, gpa_top,
+                                               pa_base);
+    }
+
+    kvm_run->cca_exit.response =
+        accepted ? 0 : REC_ENTER_FLAG_DEV_MEM_RESPONSE_REJECT;
     return 0;
 }
 

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -906,6 +906,56 @@ out:
     return ret;
 }
 
+#define KVM_REG_ARM_ID_AA64DFR0_EL1     ARM64_SYS_REG(3, 0, 0, 5, 0)
+
+static void kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
+{
+    int ret;
+    uint64_t val, newval;
+    CPUState *cs = CPU(cpu);
+
+    if (!cpu->num_bps && !cpu->num_wps) {
+        return;
+    }
+
+    newval = cpu->isar.idregs[ID_AA64DFR0_EL1_IDX];
+    if (cpu->num_bps) {
+        uint64_t ctx_cmps = FIELD_EX64(newval, ID_AA64DFR0, CTX_CMPS);
+
+        /* CTX_CMPs is never greater than BRPs */
+        ctx_cmps = MIN(ctx_cmps, cpu->num_bps - 1);
+        newval = FIELD_DP64(newval, ID_AA64DFR0, BRPS, cpu->num_bps - 1);
+        newval = FIELD_DP64(newval, ID_AA64DFR0, CTX_CMPS, ctx_cmps);
+    }
+    if (cpu->num_wps) {
+        newval = FIELD_DP64(newval, ID_AA64DFR0, WRPS, cpu->num_wps - 1);
+    }
+    ret = kvm_set_one_reg(cs, KVM_REG_ARM_ID_AA64DFR0_EL1, &newval);
+    if (ret) {
+        error_report("Failed to set KVM_REG_ARM_ID_AA64DFR0_EL1");
+        return;
+    }
+
+    /*
+     * Check if the write succeeded. KVM does offer the writable mask for this
+     * register, but this way we also check if the value we wrote was sane.
+     */
+    ret = kvm_get_one_reg(cs, KVM_REG_ARM_ID_AA64DFR0_EL1, &val);
+    if (ret) {
+        error_report("Failed to get KVM_REG_ARM_ID_AA64DFR0_EL1");
+        return;
+    }
+
+    if (val != newval) {
+        error_report("Failed to update KVM_REG_ARM_ID_AA64DFR0_EL1");
+    }
+}
+
+static void kvm_arm_configure_vcpu_regs(ARMCPU *cpu)
+{
+    kvm_arm_configure_aa64dfr0(cpu);
+}
+
 /**
  * kvm_arm_cpreg_level:
  * @regidx: KVM register index
@@ -1122,6 +1172,12 @@ void kvm_arm_reset_vcpu(ARMCPU *cpu)
         fprintf(stderr, "kvm_arm_vcpu_init failed: %s\n", strerror(-ret));
         abort();
     }
+
+    /*
+     * Before loading the KVM values into CPUState, update the KVM configuration
+     */
+    kvm_arm_configure_vcpu_regs(cpu);
+
     if (!write_kvmstate_to_list(cpu)) {
         fprintf(stderr, "write_kvmstate_to_list failed\n");
         abort();

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -590,7 +590,7 @@ int kvm_arch_get_default_type(MachineState *ms)
 
 int kvm_arch_init(MachineState *ms, KVMState *s)
 {
-    int ret = 0;
+    int ret;
     /* For ARM interrupt delivery is always asynchronous,
      * whether we are using an in-kernel VGIC or not.
      */
@@ -612,7 +612,7 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
         !kvm_check_extension(s, KVM_CAP_ARM_IRQ_LINE_LAYOUT_2)) {
         error_report("Using more than 256 vcpus requires a host kernel "
                      "with KVM_CAP_ARM_IRQ_LINE_LAYOUT_2");
-        ret = -EINVAL;
+        return -EINVAL;
     }
 
     if (kvm_check_extension(s, KVM_CAP_ARM_NISV_TO_USER)) {
@@ -634,13 +634,14 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
             warn_report("Eager Page Split support not available");
         } else if (!(s->kvm_eager_split_size & sizes)) {
             error_report("Eager Page Split requested chunk size not valid");
-            ret = -EINVAL;
+            return -EINVAL;
         } else {
             ret = kvm_vm_enable_cap(s, KVM_CAP_ARM_EAGER_SPLIT_CHUNK_SIZE, 0,
                                     s->kvm_eager_split_size);
             if (ret < 0) {
                 error_report("Enabling of Eager Page Split failed: %s",
                              strerror(-ret));
+                return ret;
             }
         }
     }
@@ -653,7 +654,7 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
     hw_breakpoints = g_array_sized_new(true, true,
                                        sizeof(HWBreakpoint), max_hw_bps);
 
-    return ret;
+    return 0;
 }
 
 unsigned long kvm_arch_vcpu_id(CPUState *cpu)

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -630,7 +630,19 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
         return -EINVAL;
     }
 
-    if (kvm_vm_check_extension(s, KVM_CAP_ARM_NISV_TO_USER)) {
+    /*
+     * KVM_CAP_ARM_NISV_TO_USER is not on the realm-ext-allowed list
+     * (kvm_realm_ext_allowed() rejects anything not relevant to
+     * confidential VMs), so KVM_ENABLE_CAP returns -EINVAL for a realm VM.
+     * The cap has no effect on realms anyway -- realm faults go through the
+     * RMM path, not the NISV-to-user path -- so skip the attempt instead of
+     * producing a spurious error_report.
+     *
+     * ms->cgs is the same realm test the series uses for the VM type and for
+     * the confidential_guest_kvm_init() call above; kvm_arm_rme_vm_type() was
+     * removed in RFC v2.
+     */
+    if (!ms->cgs && kvm_vm_check_extension(s, KVM_CAP_ARM_NISV_TO_USER)) {
         if (kvm_vm_enable_cap(s, KVM_CAP_ARM_NISV_TO_USER, 0)) {
             error_report("Failed to enable KVM_CAP_ARM_NISV_TO_USER cap");
         } else {

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -33,6 +33,7 @@
 #include "hw/pci/pci.h"
 #include "exec/memattrs.h"
 #include "system/address-spaces.h"
+#include "system/confidential-guest-support.h"
 #include "gdbstub/enums.h"
 #include "hw/core/boards.h"
 #include "hw/core/irq.h"
@@ -590,7 +591,8 @@ int kvm_arch_get_default_type(MachineState *ms)
 
 int kvm_arch_init(MachineState *ms, KVMState *s)
 {
-    int ret;
+    Error *local_err = NULL;
+    int ret = 0;
     /* For ARM interrupt delivery is always asynchronous,
      * whether we are using an in-kernel VGIC or not.
      */
@@ -603,6 +605,15 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
     kvm_halt_in_kernel_allowed = true;
 
     cap_has_mp_state = kvm_check_extension(s, KVM_CAP_MP_STATE);
+
+    /* Initialize confidential guest (Realm) if needed */
+    if (ms->cgs) {
+        ret = confidential_guest_kvm_init(ms->cgs, &local_err);
+            if (ret < 0) {
+                error_report_err(local_err);
+                return ret;
+        }
+    }
 
     /* Check whether user space can specify guest syndrome value */
     cap_has_inject_serror_esr =
@@ -654,7 +665,7 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
     hw_breakpoints = g_array_sized_new(true, true,
                                        sizeof(HWBreakpoint), max_hw_bps);
 
-    return 0;
+    return ret;
 }
 
 unsigned long kvm_arch_vcpu_id(CPUState *cpu)

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -951,9 +951,43 @@ static void kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
     }
 }
 
+#define KVM_REG_ARM_PMCR_EL0            ARM64_SYS_REG(3, 3, 9, 12, 0)
+
+static void kvm_arm_configure_pmcr(ARMCPU *cpu)
+{
+    int ret;
+    uint64_t val, newval;
+    CPUState *cs = CPU(cpu);
+
+    if (cpu->num_pmu_ctrs == -1) {
+        return;
+    }
+
+    newval = FIELD_DP64(cpu->isar.reset_pmcr_el0, PMCR, N, cpu->num_pmu_ctrs);
+    ret = kvm_set_one_reg(cs, KVM_REG_ARM_PMCR_EL0, &newval);
+    if (ret) {
+        error_report("Failed to set KVM_REG_ARM_PMCR_EL0");
+        return;
+    }
+
+    /*
+     * Check if the write succeeded, since older versions of KVM ignore it.
+     */
+    ret = kvm_get_one_reg(cs, KVM_REG_ARM_PMCR_EL0, &val);
+    if (ret) {
+        error_report("Failed to get KVM_REG_ARM_PMCR_EL0");
+        return;
+    }
+
+    if (val != newval) {
+        error_report("Failed to update KVM_REG_ARM_PMCR_EL0");
+    }
+}
+
 static void kvm_arm_configure_vcpu_regs(ARMCPU *cpu)
 {
     kvm_arm_configure_aa64dfr0(cpu);
+    kvm_arm_configure_pmcr(cpu);
 }
 
 /**

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -324,7 +324,7 @@ static bool kvm_arm_get_host_cpu_features(ARMHostCPUFeatures *ahcf)
                              1 << KVM_ARM_VCPU_PTRAUTH_GENERIC);
     }
 
-    if (kvm_check_extension(kvm_state, KVM_CAP_ARM_PMU_V3)) {
+    if (kvm_vm_check_extension(kvm_state, KVM_CAP_ARM_PMU_V3)) {
         init.features[0] |= 1 << KVM_ARM_VCPU_PMU_V3;
         pmu_supported = true;
         features |= 1ULL << ARM_FEATURE_PMU;
@@ -630,7 +630,7 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
         return -EINVAL;
     }
 
-    if (kvm_check_extension(s, KVM_CAP_ARM_NISV_TO_USER)) {
+    if (kvm_vm_check_extension(s, KVM_CAP_ARM_NISV_TO_USER)) {
         if (kvm_vm_enable_cap(s, KVM_CAP_ARM_NISV_TO_USER, 0)) {
             error_report("Failed to enable KVM_CAP_ARM_NISV_TO_USER cap");
         } else {
@@ -661,11 +661,11 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
         }
     }
 
-    max_hw_wps = kvm_check_extension(s, KVM_CAP_GUEST_DEBUG_HW_WPS);
+    max_hw_wps = kvm_vm_check_extension(s, KVM_CAP_GUEST_DEBUG_HW_WPS);
     hw_watchpoints = g_array_sized_new(true, true,
                                        sizeof(HWWatchpoint), max_hw_wps);
 
-    max_hw_bps = kvm_check_extension(s, KVM_CAP_GUEST_DEBUG_HW_BPS);
+    max_hw_bps = kvm_vm_check_extension(s, KVM_CAP_GUEST_DEBUG_HW_BPS);
     hw_breakpoints = g_array_sized_new(true, true,
                                        sizeof(HWBreakpoint), max_hw_bps);
 
@@ -1904,7 +1904,7 @@ void kvm_arm_pvtime_init(ARMCPU *cpu, uint64_t ipa)
 
 void kvm_arm_steal_time_finalize(ARMCPU *cpu, Error **errp)
 {
-    bool has_steal_time = kvm_check_extension(kvm_state, KVM_CAP_STEAL_TIME);
+    bool has_steal_time = kvm_vm_check_extension(kvm_state, KVM_CAP_STEAL_TIME);
 
     if (cpu->kvm_steal_time == ON_OFF_AUTO_AUTO) {
         if (!has_steal_time || !arm_feature(&cpu->env, ARM_FEATURE_AARCH64)) {

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -920,14 +920,14 @@ out:
 
 #define KVM_REG_ARM_ID_AA64DFR0_EL1     ARM64_SYS_REG(3, 0, 0, 5, 0)
 
-static void kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
+static bool kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
 {
     int ret;
     uint64_t val, newval;
     CPUState *cs = CPU(cpu);
 
     if (!cpu->num_bps && !cpu->num_wps) {
-        return;
+        return true;
     }
 
     newval = cpu->isar.idregs[ID_AA64DFR0_EL1_IDX];
@@ -944,8 +944,9 @@ static void kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
     }
     ret = kvm_set_one_reg(cs, KVM_REG_ARM_ID_AA64DFR0_EL1, &newval);
     if (ret) {
-        error_report("Failed to set KVM_REG_ARM_ID_AA64DFR0_EL1");
-        return;
+        error_report("Failed to set KVM_REG_ARM_ID_AA64DFR0_EL1: %s",
+                     strerror(-ret));
+        return false;
     }
 
     /*
@@ -954,32 +955,59 @@ static void kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
      */
     ret = kvm_get_one_reg(cs, KVM_REG_ARM_ID_AA64DFR0_EL1, &val);
     if (ret) {
-        error_report("Failed to get KVM_REG_ARM_ID_AA64DFR0_EL1");
-        return;
+        error_report("Failed to get KVM_REG_ARM_ID_AA64DFR0_EL1: %s",
+                     strerror(-ret));
+        return false;
     }
 
     if (val != newval) {
         error_report("Failed to update KVM_REG_ARM_ID_AA64DFR0_EL1");
+        return false;
     }
+
+    return true;
 }
 
 #define KVM_REG_ARM_PMCR_EL0            ARM64_SYS_REG(3, 3, 9, 12, 0)
 
-static void kvm_arm_configure_pmcr(ARMCPU *cpu)
+static bool kvm_arm_configure_pmcr(ARMCPU *cpu)
 {
+    unsigned int nr_counters = cpu->num_pmu_ctrs;
+    struct kvm_device_attr attr = {
+        .group = KVM_ARM_VCPU_PMU_V3_CTRL,
+        .attr = KVM_ARM_VCPU_PMU_V3_SET_NR_COUNTERS,
+        .addr = (uintptr_t)&nr_counters,
+    };
     int ret;
     uint64_t val, newval;
     CPUState *cs = CPU(cpu);
 
     if (cpu->num_pmu_ctrs == -1) {
-        return;
+        return true;
+    }
+
+    /*
+     * Realms restrict which registers userspace may write. Prefer the PMU
+     * device attribute, which configures the VM-wide PMCR_EL0.N value without
+     * requiring a SET_ONE_REG allow-list entry. Fall back for older kernels.
+     */
+    ret = kvm_vcpu_ioctl(cs, KVM_HAS_DEVICE_ATTR, &attr);
+    if (!ret) {
+        ret = kvm_vcpu_ioctl(cs, KVM_SET_DEVICE_ATTR, &attr);
+        if (ret) {
+            error_report("Failed to set number of KVM PMU counters: %s",
+                         strerror(-ret));
+            return false;
+        }
+        return true;
     }
 
     newval = FIELD_DP64(cpu->isar.reset_pmcr_el0, PMCR, N, cpu->num_pmu_ctrs);
     ret = kvm_set_one_reg(cs, KVM_REG_ARM_PMCR_EL0, &newval);
     if (ret) {
-        error_report("Failed to set KVM_REG_ARM_PMCR_EL0");
-        return;
+        error_report("Failed to set KVM_REG_ARM_PMCR_EL0: %s",
+                     strerror(-ret));
+        return false;
     }
 
     /*
@@ -987,19 +1015,22 @@ static void kvm_arm_configure_pmcr(ARMCPU *cpu)
      */
     ret = kvm_get_one_reg(cs, KVM_REG_ARM_PMCR_EL0, &val);
     if (ret) {
-        error_report("Failed to get KVM_REG_ARM_PMCR_EL0");
-        return;
+        error_report("Failed to get KVM_REG_ARM_PMCR_EL0: %s",
+                     strerror(-ret));
+        return false;
     }
 
     if (val != newval) {
         error_report("Failed to update KVM_REG_ARM_PMCR_EL0");
+        return false;
     }
+
+    return true;
 }
 
-static void kvm_arm_configure_vcpu_regs(ARMCPU *cpu)
+static bool kvm_arm_configure_vcpu_regs(ARMCPU *cpu)
 {
-    kvm_arm_configure_aa64dfr0(cpu);
-    kvm_arm_configure_pmcr(cpu);
+    return kvm_arm_configure_aa64dfr0(cpu) && kvm_arm_configure_pmcr(cpu);
 }
 
 /**
@@ -1222,7 +1253,9 @@ void kvm_arm_reset_vcpu(ARMCPU *cpu)
     /*
      * Before loading the KVM values into CPUState, update the KVM configuration
      */
-    kvm_arm_configure_vcpu_regs(cpu);
+    if (!kvm_arm_configure_vcpu_regs(cpu)) {
+        abort();
+    }
 
     if (!write_kvmstate_to_list(cpu)) {
         fprintf(stderr, "write_kvmstate_to_list failed\n");

--- a/target/arm/kvm.c
+++ b/target/arm/kvm.c
@@ -53,6 +53,9 @@ static bool cap_has_mp_state;
 static bool cap_has_inject_serror_esr;
 static bool cap_has_inject_ext_dabt;
 
+#define KVM_REG_ARM_ID_AA64DFR0_EL1     ARM64_SYS_REG(3, 0, 0, 5, 0)
+#define KVM_REG_ARM_PMCR_EL0            ARM64_SYS_REG(3, 3, 9, 12, 0)
+
 /**
  * ARMHostCPUFeatures: information about the host CPU (identified
  * by asking the host kernel)
@@ -829,8 +832,18 @@ static uint64_t *kvm_arm_get_cpreg_ptr(ARMCPU *cpu, uint64_t regidx)
  * cpreg list of arbitrary system registers, false if it is synchronized
  * by hand using code in kvm_arch_get/put_registers().
  */
-static bool kvm_arm_reg_syncs_via_cpreg_list(uint64_t regidx)
+static bool kvm_arm_reg_syncs_via_cpreg_list(ARMCPU *cpu, uint64_t regidx)
 {
+    /*
+     * Realm KVM exposes PMCR_EL0 so userspace can discover the counter
+     * count, but the Realm SET_ONE_REG allow-list does not permit writing
+     * it.  PMU configuration is handled explicitly through the PMU device
+     * attribute instead.
+     */
+    if (cpu->kvm_rme && regidx == KVM_REG_ARM_PMCR_EL0) {
+        return false;
+    }
+
     switch (regidx & KVM_REG_ARM_COPROC_MASK) {
     case KVM_REG_ARM_CORE:
     case KVM_REG_ARM64_SVE:
@@ -874,7 +887,7 @@ static int kvm_arm_init_cpreg_list(ARMCPU *cpu)
     qsort(&rlp->reg, rlp->n, sizeof(rlp->reg[0]), compare_u64);
 
     for (i = 0, arraylen = 0; i < rlp->n; i++) {
-        if (!kvm_arm_reg_syncs_via_cpreg_list(rlp->reg[i])) {
+        if (!kvm_arm_reg_syncs_via_cpreg_list(cpu, rlp->reg[i])) {
             continue;
         }
         switch (rlp->reg[i] & KVM_REG_SIZE_MASK) {
@@ -896,7 +909,7 @@ static int kvm_arm_init_cpreg_list(ARMCPU *cpu)
 
     for (i = 0, arraylen = 0; i < rlp->n; i++) {
         uint64_t regidx = rlp->reg[i];
-        if (!kvm_arm_reg_syncs_via_cpreg_list(regidx)) {
+        if (!kvm_arm_reg_syncs_via_cpreg_list(cpu, regidx)) {
             continue;
         }
         cpu->cpreg_indexes[arraylen] = regidx;
@@ -917,8 +930,6 @@ out:
     g_free(rlp);
     return ret;
 }
-
-#define KVM_REG_ARM_ID_AA64DFR0_EL1     ARM64_SYS_REG(3, 0, 0, 5, 0)
 
 static bool kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
 {
@@ -967,8 +978,6 @@ static bool kvm_arm_configure_aa64dfr0(ARMCPU *cpu)
 
     return true;
 }
-
-#define KVM_REG_ARM_PMCR_EL0            ARM64_SYS_REG(3, 3, 9, 12, 0)
 
 static bool kvm_arm_configure_pmcr(ARMCPU *cpu)
 {

--- a/target/arm/kvm_arm.h
+++ b/target/arm/kvm_arm.h
@@ -250,4 +250,14 @@ char *kvm_print_register_name(uint64_t regidx);
  */
 void kvm_arm_rme_vcpu_init(ARMCPU *cpu);
 
+/**
+ * kvm_arm_rme_setup_gpa
+ * @highest_gpa: highest address of the lower half of the guest address space
+ * @pci_bus: The main PCI bus, for which PCI queries DMA address spaces
+ *
+ * Setup the guest-physical address space for a Realm. Install a memory region
+ * and notifier to manage the shared upper half of the address space.
+ */
+void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus);
+
 #endif

--- a/target/arm/kvm_arm.h
+++ b/target/arm/kvm_arm.h
@@ -240,4 +240,14 @@ void arm_gic_cap_kvm_probe(GICCapability *v2, GICCapability *v3);
  */
 char *kvm_print_register_name(uint64_t regidx);
 
+/**
+ * kvm_arm_rme_vcpu_init
+ * @cs: the CPU
+ *
+ * If the user requested a Realm, setup the given vCPU accordingly. Realm vCPUs
+ * behave a little differently, for example most of their register state is
+ * hidden from the host.
+ */
+void kvm_arm_rme_vcpu_init(ARMCPU *cpu);
+
 #endif

--- a/target/arm/kvm_arm.h
+++ b/target/arm/kvm_arm.h
@@ -260,4 +260,12 @@ void kvm_arm_rme_vcpu_init(ARMCPU *cpu);
  */
 void kvm_arm_rme_init_gpa_space(hwaddr highest_gpa, PCIBus *pci_bus);
 
+/**
+ * kvm_arm_rme_get_dma_as:
+ *
+ * Return the shared-IPA DMA address space for a Realm, or NULL for a
+ * non-Realm machine or before the Realm address space has been initialized.
+ */
+AddressSpace *kvm_arm_rme_get_dma_as(void);
+
 #endif

--- a/target/arm/meson.build
+++ b/target/arm/meson.build
@@ -19,7 +19,10 @@ arm_common_ss.add(files(
 arm_common_system_ss.add(files(
   'arm-qmp-cmds.c',
 ))
-arm_system_ss.add(when: 'CONFIG_KVM', if_true: files('hyp_gdbstub.c', 'kvm.c'))
+arm_system_ss.add(when: 'CONFIG_KVM', if_true: files(
+  'hyp_gdbstub.c',
+  'kvm.c',
+  'kvm-rme.c'))
 arm_system_ss.add(when: 'CONFIG_HVF', if_true: files('hyp_gdbstub.c'))
 
 arm_user_ss.add(files('cpu.c'))


### PR DESCRIPTION
## Summary

- rebase the Arm CCA work onto `nvidia_unstable-11.0` at `29e60cad77` (`1:11.0.0+nvidia-unstable8-1`)
- import the Linaro Arm CCA Realm RFC v2 series and retain the NVIDIA runtime `KVM_CAP_ARM_RMI` discovery needed by production kernels
- add the RME device-assignment patches and the follow-up correctness, validation, unwind, and concurrency fixes from review
- restore the NVIDIA `address_space_range_is_ram()` prerequisite that was present on the former development base but absent from unstable8
- keep imported RFC authorship and provenance while marking the carry patches `NVIDIA: SAUCE:` and adding Ian May sign-offs

## Validation

- per-commit commit-message and sign-off audit across all 54 commits
- `scripts/checkpatch.pl` pass with no errors; remaining warnings are limited to imported Linux header and MAINTAINERS expectations
- clean local `aarch64-softmmu` build
- clean local all-target build, including targets without IOMMUFD
- QAPI firmware schema regression test
- KVM-only AArch64 build on Vera using kernel `7.0.0-3f8dc0153+`, with runtime `KVM_CAP_ARM_RMI=248`
- 8-vCPU, 16 GiB CPU Realm boot through UEFI, GRUB, Ubuntu, cloud-init, and the serial login prompt while another Realm remained active
- full arm64 Debian binary package build (`dpkg-buildpackage -b -uc -us -j64`), including all system and user targets

## Remaining hardware coverage

RME device-assignment runtime coverage is not included yet. The available Vera host has no device currently bound to `vfio-pci` and no designated sacrificial BDF; detaching a production GPU, NVMe device, or NIC was intentionally avoided. The RME-DA code is covered by the real Arm KVM build and the full package build.