### PR TITLE
NVIDIA: SAUCE: hw/vfio: thread vf-token through iommufd bind

### DIFF
--- a/hw/vfio/iommufd.c
+++ b/hw/vfio/iommufd.c
@@ -129,6 +129,7 @@ static void iommufd_cdev_kvm_device_del(VFIODevice *vbasedev)
 
 static bool iommufd_cdev_connect_and_bind(VFIODevice *vbasedev, Error **errp)
 {
+    VFIOPCIDevice *vdev = vfio_pci_from_vfio_device(vbasedev);
     IOMMUFDBackend *iommufd = vbasedev->iommufd;
     struct vfio_device_bind_iommufd bind = {
         .argsz = sizeof(bind),
@@ -154,6 +155,15 @@ static bool iommufd_cdev_connect_and_bind(VFIODevice *vbasedev, Error **errp)
 
     /* Bind device to iommufd */
     bind.iommufd = iommufd->fd;
+
+    /*
+     * Pass the VF token when binding a PCI device.
+     */
+    if (vdev && !qemu_uuid_is_null(&vdev->vf_token)) {
+        bind.flags |= VFIO_DEVICE_BIND_FLAG_TOKEN;
+        bind.token_uuid_ptr = (uintptr_t)&vdev->vf_token;
+    }
+
     if (ioctl(vbasedev->fd, VFIO_DEVICE_BIND_IOMMUFD, &bind)) {
         error_setg_errno(errp, errno, "error bind device fd=%d to iommufd=%d",
                          vbasedev->fd, bind.iommufd);


### PR DESCRIPTION
A VF fails to bind through the iommufd/cdev backend when its PF is bound to vfio-pci and requires a matching VF token.

QEMU currently initializes struct vfio_device_bind_iommufd without the token flag or token UUID.

Pass the existing vf-token device property to the IOMMUFD bind ioctl for PCI devices.
