### PR TITLE
NVIDIA: SAUCE: hw/arm/tegra241-cmdqv: Keep VINTF page0 region alive

### DIFF
--- a/hw/arm/tegra241-cmdqv.c
+++ b/hw/arm/tegra241-cmdqv.c
@@ -131,35 +131,37 @@ static void tegra241_cmdqv_reset_vcmdq_cache(Tegra241CMDQV *cmdqv, int index)
 
 static void tegra241_cmdqv_guest_unmap_vintf_page0(Tegra241CMDQV *cmdqv)
 {
-    if (!cmdqv->mr_vintf_page0) {
+    if (!cmdqv->mr_vintf_page0_initialized) {
         return;
     }
 
-    memory_region_del_subregion(&cmdqv->mmio_cmdqv, cmdqv->mr_vintf_page0);
-    object_unparent(OBJECT(cmdqv->mr_vintf_page0));
-    g_free(cmdqv->mr_vintf_page0);
-    cmdqv->mr_vintf_page0 = NULL;
+    /*
+     * Keep the region parented: old FlatViews can retain a pointer to it
+     * until their RCU callbacks have run.
+     */
+    memory_region_set_enabled(&cmdqv->mr_vintf_page0, false);
 }
 
 static void tegra241_cmdqv_guest_map_vintf_page0(Tegra241CMDQV *cmdqv)
 {
     char *name;
 
-    if (cmdqv->mr_vintf_page0) {
+    if (cmdqv->mr_vintf_page0_initialized) {
+        memory_region_set_enabled(&cmdqv->mr_vintf_page0, true);
         return;
     }
 
     name = g_strdup_printf("%s vintf-page0",
                            memory_region_name(&cmdqv->mmio_cmdqv));
-    cmdqv->mr_vintf_page0 = g_malloc0(sizeof(*cmdqv->mr_vintf_page0));
-    memory_region_init_ram_device_ptr(cmdqv->mr_vintf_page0,
+    memory_region_init_ram_device_ptr(&cmdqv->mr_vintf_page0,
                                       memory_region_owner(&cmdqv->mmio_cmdqv),
                                       name, VINTF_PAGE_SIZE,
                                       cmdqv->vintf_page0);
-    memory_region_set_skip_iommu_map(cmdqv->mr_vintf_page0, true);
+    memory_region_set_skip_iommu_map(&cmdqv->mr_vintf_page0, true);
     memory_region_add_subregion_overlap(&cmdqv->mmio_cmdqv,
                                         CMDQV_VINTF_PAGE0_BASE,
-                                        cmdqv->mr_vintf_page0, 1);
+                                        &cmdqv->mr_vintf_page0, 1);
+    cmdqv->mr_vintf_page0_initialized = true;
     g_free(name);
 }
 

--- a/hw/arm/tegra241-cmdqv.h
+++ b/hw/arm/tegra241-cmdqv.h
@@ -49,7 +49,8 @@ typedef struct Tegra241CMDQV {
     IOMMUFDVeventq *veventq;
     IOMMUFDHWqueue *vcmdq[TEGRA241_CMDQV_MAX_CMDQ];
     void *vintf_page0;
-    MemoryRegion *mr_vintf_page0;
+    MemoryRegion mr_vintf_page0;
+    bool mr_vintf_page0_initialized;
 
     /* CMDQ-V Config page register cache */
     uint32_t config;


### PR DESCRIPTION
  ## Summary

  Fix a use-after-free in the Tegra241 CMDQV VINTF page0 memory region
  during guest reset or VINTF disable.

  Related: NVBug 6676450

  ## Root cause

  The VINTF page0 unmap path removed, unparented, and immediately freed its
  dynamically allocated `MemoryRegion`.

  QEMU FlatViews retain raw `MemoryRegion` pointers and release their
  references asynchronously through RCU. An old FlatView could therefore
  access the VINTF page0 region after it had been freed, causing heap
  corruption or a QEMU crash during address-space cleanup.

  The observed crash path included:

  ```text
  object_unref
  address_space_dispatch_free
  flatview_destroy
  call_rcu_thread
```
  This was introduced by upstream commit:

  5965b81ce283 ("hw/arm/tegra241-cmdqv: Use mmap'd host VINTF page0 for virtual VINTF page0")

  ## Fix

  Embed the VINTF page0 MemoryRegion in Tegra241CMDQV and initialize
  and add it only once.

  When the guest disables VINTF or resets, disable the region with
  memory_region_set_enabled(). Re-enable the same region when VINTF is
  enabled again.

  New FlatViews omit the disabled region, while old FlatViews continue to
  reference valid storage until their RCU cleanup completes. This also
  eliminates per-reset allocation and freeing of the region.

  ## Reproducer

  Start an Arm virt guest with one passed-through device behind an
  accelerated SMMUv3 configured with cmdqv=on, and add an HMP monitor:

  -monitor unix:/tmp/qmon.sock,server,nowait

  Freed-memory poisoning makes the failure reliable without an ASan build:

  GLIBC_TUNABLES=glibc.malloc.tcache_count=0 \
  MALLOC_PERTURB_=165 \
  MALLOC_CHECK_=3 \
  qemu-system-aarch64 <options>

  After info mtree shows the VINTF page0 region, reset through the
  monitor:

  printf 'system_reset\n' |
      timeout 5 nc -N -U /tmp/qmon.sock

  The unpatched binary crashed on the first reset with SIGSEGV. The core
  showed object_unref() receiving the poisoned pointer
  0xa5a5a5a5a5a5a5a5 from deferred address-space cleanup.

  ## Validation

  - Unpatched, one CMDQV instance: SIGSEGV on the first reset
  - Patched, one CMDQV instance: 100/100 resets completed successfully
  - scripts/checkpatch.pl: 0 errors and 0 warnings
  - Patch applies cleanly to current upstream/master